### PR TITLE
feat: about page animations through re-usable wrapper widget

### DIFF
--- a/docs/sections/completed-subjects.md
+++ b/docs/sections/completed-subjects.md
@@ -55,6 +55,7 @@ List of demonstrated elements inside the codebase, divided by categories
 - Tween and TweenSequence
 - RotationTransition, AnimatedOpacity
 - Example of Staggered animations through CurvedAnimation and intervals
+- Re-use animation through a behavioral wrapper widget with a child attribute
 
 ### Dart language
 

--- a/lib/features/about/card.header.animation.widget.dart
+++ b/lib/features/about/card.header.animation.widget.dart
@@ -14,7 +14,8 @@ class CardHeaderAnimation extends StatelessWidget {
     return SizedBox(
         width: 200,
         child: Center(
-          child: HorizontalSlideIntroWidget(child: Lottie.asset(animationUtils.getAnimationPath())),
+          child: HorizontalSlideIntroWidget(
+              duration: const Duration(seconds: 6), child: Lottie.asset(animationUtils.getAnimationPath())),
         ));
   }
 }

--- a/lib/features/about/card.header.animation.widget.dart
+++ b/lib/features/about/card.header.animation.widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:guess_the_text/service.locator.dart';
+import 'package:guess_the_text/theme/widgets/animations/horizontal.slide.intro.widget.dart';
 import 'package:guess_the_text/utils/animation.utils.dart';
 import 'package:lottie/lottie.dart';
 
@@ -13,7 +14,7 @@ class CardHeaderAnimation extends StatelessWidget {
     return SizedBox(
         width: 200,
         child: Center(
-          child: Lottie.asset(animationUtils.getAnimationPath()),
+          child: HorizontalSlideIntroWidget(child: Lottie.asset(animationUtils.getAnimationPath())),
         ));
   }
 }

--- a/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
+++ b/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
@@ -5,8 +5,18 @@ const welcomeImage = 'assets/images/hangman-happy.svg';
 class HorizontalSlideIntroWidget extends StatefulWidget {
   final Widget child;
   final void Function()? onAnimationComplete;
+  final Duration duration;
+  final Offset offsetStart;
+  final Offset offsetEnd;
 
-  const HorizontalSlideIntroWidget({Key? key, required this.child, this.onAnimationComplete}) : super(key: key);
+  const HorizontalSlideIntroWidget(
+      {Key? key,
+      required this.child,
+      this.onAnimationComplete,
+      this.duration = const Duration(seconds: 2),
+      this.offsetStart = const Offset(1, -0.25),
+      this.offsetEnd = const Offset(0, 0)})
+      : super(key: key);
 
   @override
   State<HorizontalSlideIntroWidget> createState() => _HorizontalSlideIntroWidgetState();
@@ -20,12 +30,12 @@ class _HorizontalSlideIntroWidgetState extends State<HorizontalSlideIntroWidget>
   void initState() {
     super.initState();
 
-    animController = AnimationController(duration: const Duration(milliseconds: 4000), vsync: this);
+    animController = AnimationController(duration: widget.duration, vsync: this);
     animController.addListener(() {
       setState(() {});
     });
 
-    slideAnim = Tween<Offset>(begin: const Offset(1, -0.25), end: const Offset(0, 0))
+    slideAnim = Tween<Offset>(begin: widget.offsetStart, end: widget.offsetEnd)
         .chain(CurveTween(curve: Curves.ease))
         .animate(animController);
 

--- a/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
+++ b/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+const welcomeImage = 'assets/images/hangman-happy.svg';
+
+class HorizontalSlideIntroWidget extends StatefulWidget {
+  final Widget child;
+  final void Function()? onAnimationComplete;
+
+  const HorizontalSlideIntroWidget({Key? key, required this.child, this.onAnimationComplete}) : super(key: key);
+
+  @override
+  State<HorizontalSlideIntroWidget> createState() => _HorizontalSlideIntroWidgetState();
+}
+
+class _HorizontalSlideIntroWidgetState extends State<HorizontalSlideIntroWidget> with SingleTickerProviderStateMixin {
+  late final AnimationController animController;
+  late final Animation<Offset> slideAnim;
+
+  @override
+  void initState() {
+    super.initState();
+
+    animController = AnimationController(duration: const Duration(milliseconds: 4000), vsync: this);
+    animController.addListener(() {
+      setState(() {});
+    });
+
+    slideAnim = Tween<Offset>(begin: const Offset(1, -0.25), end: const Offset(0, 0))
+        .chain(CurveTween(curve: Curves.ease))
+        .animate(animController);
+
+    Future.delayed(const Duration(milliseconds: 300), () {
+      animController.forward(from: 0).then((value) => {
+            if (widget.onAnimationComplete != null) {widget.onAnimationComplete!()}
+          });
+    });
+  }
+
+  @override
+  void dispose() {
+    animController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SlideTransition(position: slideAnim, child: widget.child);
+  }
+}


### PR DESCRIPTION
### Elements addressed by this pull request

- example of a re-usable animation wrapper

### Checklist

- [ ] Unit tests completed
- [x] Tested on all supported platforms (Android, iOS, web...)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Démo

https://user-images.githubusercontent.com/3459255/173190414-2449c0cd-6ca8-41a6-a931-5165a6950191.mov

