### PR TITLE
refactor: re-usable widget for bg images asssets covering whole screen

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-## [Issue xxxxxxx](https://github.com/amwebexpert/guess_the_text/issues/xxxxxxx)
-
 ### Elements addressed by this pull request
 
 - 
@@ -8,8 +6,9 @@
 
 ### Checklist
 
-- [ ] Unit tests completed
-- [ ] Tested on all supported platforms (Android, iOS, web...)
+- [ ] Unit tests completed (will be )
+- [ ] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
+- [ ] Added corresponding screen capture or video
 - [ ] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 
 ### Demos

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ### Checklist
 
-- [ ] Unit tests completed (will be )
+- [ ] Unit tests completed
 - [ ] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
 - [ ] Added corresponding screen capture or video
 - [ ] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+## [Issue xxxxxxx](https://github.com/amwebexpert/guess_the_text/issues/xxxxxxx)
+
 ### Elements addressed by this pull request
 
 - 

--- a/lib/features/about/about.screen.dart
+++ b/lib/features/about/about.screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
 import 'package:guess_the_text/theme/widgets/app.bar.title.widget.dart';
+import 'package:guess_the_text/theme/widgets/full.screen.bg.image.widget.dart';
 
 import 'card.widget.dart';
 
@@ -37,21 +38,14 @@ class _AboutWidgetState extends State<AboutWidget> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
-    final screenSize = MediaQuery.of(context).size;
     const String backgroundImage = 'assets/images/backgrounds/background-pexels-pixabay-461940.jpg';
 
     return Scaffold(
         appBar: AppBar(
           title: AppBarTitle(title: localizations.about),
         ),
-        body: Container(
-          width: screenSize.width,
-          height: screenSize.height,
-          decoration: const BoxDecoration(
-              image: DecorationImage(
-            image: AssetImage(backgroundImage),
-            fit: BoxFit.cover,
-          )),
+        body: FullScreenAssetBackground(
+          assetImagePath: backgroundImage,
           child: AnimatedOpacity(
             opacity: isVisible ? 1.0 : 0.0,
             duration: const Duration(milliseconds: 800),

--- a/lib/features/categories/categories.list.widget.dart
+++ b/lib/features/categories/categories.list.widget.dart
@@ -7,6 +7,7 @@ import 'package:guess_the_text/features/game/game.store.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
 
 import 'package:guess_the_text/theme/widgets/app.bar.title.widget.dart';
+import 'package:guess_the_text/theme/widgets/full.screen.bg.image.widget.dart';
 
 class CategoriesListWidget extends StatelessWidget {
   static const String backgroundImage = 'assets/images/backgrounds/background-pexels-pixabay-461940.jpg';
@@ -23,8 +24,8 @@ class CategoriesListWidget extends StatelessWidget {
       appBar: AppBar(
         title: AppBarTitle(title: AppLocalizations.of(context)!.categories),
       ),
-      body: Container(
-        decoration: const BoxDecoration(image: DecorationImage(image: AssetImage(backgroundImage), fit: BoxFit.cover)),
+      body: FullScreenAssetBackground(
+        assetImagePath: backgroundImage,
         child: Padding(
           padding: EdgeInsets.symmetric(vertical: spacing(1)),
           child: ListView.builder(

--- a/lib/features/settings/settings.screen.dart
+++ b/lib/features/settings/settings.screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:guess_the_text/features/settings/hero.settings.widget.dart';
 import 'package:guess_the_text/service.locator.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
+import 'package:guess_the_text/theme/widgets/full.screen.bg.image.widget.dart';
 import 'package:guess_the_text/utils/language.utils.dart';
 import 'package:guess_the_text/theme/widgets/app.bar.title.widget.dart';
 
@@ -39,19 +40,14 @@ class _SettingsWidgetState extends State<SettingsWidget> {
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     final isDarkTheme = Theme.of(context).brightness == Brightness.dark;
-    final screenSize = MediaQuery.of(context).size;
 
     return Observer(builder: (context) {
       return Scaffold(
         appBar: AppBar(
           title: AppBarTitle(title: localizations.preferences),
         ),
-        body: Container(
-          width: screenSize.width,
-          height: screenSize.height,
-          decoration: BoxDecoration(
-              image: DecorationImage(
-                  image: AssetImage(isDarkTheme ? backgroundImageDark : backgroundImageLight), fit: BoxFit.cover)),
+        body: FullScreenAssetBackground(
+          assetImagePath: isDarkTheme ? backgroundImageDark : backgroundImageLight,
           child: SingleChildScrollView(
             child: Padding(
               padding: EdgeInsets.symmetric(vertical: spacing(1)),

--- a/lib/theme/widgets/full.screen.bg.image.widget.dart
+++ b/lib/theme/widgets/full.screen.bg.image.widget.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class FullScreenAssetBackground extends StatelessWidget {
+  final Widget child;
+  final String assetImagePath;
+
+  const FullScreenAssetBackground({Key? key, required this.child, required this.assetImagePath}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+
+    return Container(
+      width: screenSize.width,
+      height: screenSize.height,
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage(assetImagePath),
+          fit: BoxFit.cover,
+        ),
+      ),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
### Elements addressed by this pull request

Created `FullScreenAssetBackground` widget to apply `DRY` rule (dont repeat yourself):
- background image from assets
- covering whole screen
- apply this pattern for 3 screens (see demos)

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android
About | Settings | Categories
------ | -------- | ------------
![image](https://user-images.githubusercontent.com/3459255/173468020-1e4dc58a-66ce-481a-8bdf-368d1872573e.png) | ![image](https://user-images.githubusercontent.com/3459255/173468078-1f8c0baf-2e67-4e0b-901f-79ea14c97d15.png) | ![image](https://user-images.githubusercontent.com/3459255/173468117-b5957e06-97f3-48cd-8090-17b17515f8c2.png)


#### Webapp
About | Settings | Categories
------ | -------- | ------------
![image](https://user-images.githubusercontent.com/3459255/173467073-f24af8f0-09c1-4e94-b99d-20ba94d2b6fd.png) | ![image](https://user-images.githubusercontent.com/3459255/173467119-aa5698a4-1db7-46bf-bea5-f2e0f08b9a97.png) | ![image](https://user-images.githubusercontent.com/3459255/173467155-0a452f96-ff42-42d2-9be3-1bea8fc5c8e3.png)
