### PR TITLE
feat: QR code animation

### DIFF
--- a/lib/features/about/card.header.animation.widget.dart
+++ b/lib/features/about/card.header.animation.widget.dart
@@ -14,7 +14,7 @@ class CardHeaderAnimation extends StatelessWidget {
     return SizedBox(
         width: 200,
         child: Center(
-          child: HorizontalSlideIntroWidget(
+          child: SlideIntroWidget(
               duration: const Duration(seconds: 6), child: Lottie.asset(animationUtils.getAnimationPath())),
         ));
   }

--- a/lib/features/game/challenge/on.the.fly.chalenge.qr.widget.dart
+++ b/lib/features/game/challenge/on.the.fly.chalenge.qr.widget.dart
@@ -5,6 +5,7 @@ import 'package:guess_the_text/features/game/challenge/on.the.fly.challenge.mode
 import 'package:guess_the_text/service.locator.dart';
 import 'package:guess_the_text/services/qr/qr.code.service.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
+import 'package:guess_the_text/theme/widgets/animations/scaling.intro.widget.dart';
 
 class OnTheFlyChalengeQrWidget extends StatelessWidget {
   final QrCodeService qrCodeService = serviceLocator.get();
@@ -41,7 +42,7 @@ class OnTheFlyChalengeQrWidget extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyText1,
                 ),
-                Expanded(child: SvgPicture.string(qrCodeImage)),
+                Expanded(child: ScalingIntroWidget(child: SvgPicture.string(qrCodeImage))),
                 ElevatedButton(
                   child: Text(localizations.actionClose),
                   onPressed: () => Navigator.pop(context),

--- a/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
+++ b/lib/theme/widgets/animations/horizontal.slide.intro.widget.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 
 const welcomeImage = 'assets/images/hangman-happy.svg';
 
-class HorizontalSlideIntroWidget extends StatefulWidget {
+class SlideIntroWidget extends StatefulWidget {
   final Widget child;
   final void Function()? onAnimationComplete;
   final Duration duration;
   final Offset offsetStart;
   final Offset offsetEnd;
 
-  const HorizontalSlideIntroWidget(
+  const SlideIntroWidget(
       {Key? key,
       required this.child,
       this.onAnimationComplete,
@@ -19,10 +19,10 @@ class HorizontalSlideIntroWidget extends StatefulWidget {
       : super(key: key);
 
   @override
-  State<HorizontalSlideIntroWidget> createState() => _HorizontalSlideIntroWidgetState();
+  State<SlideIntroWidget> createState() => _SlideIntroWidgetState();
 }
 
-class _HorizontalSlideIntroWidgetState extends State<HorizontalSlideIntroWidget> with SingleTickerProviderStateMixin {
+class _SlideIntroWidgetState extends State<SlideIntroWidget> with SingleTickerProviderStateMixin {
   late final AnimationController animController;
   late final Animation<Offset> slideAnim;
 

--- a/lib/theme/widgets/animations/scaling.intro.widget.dart
+++ b/lib/theme/widgets/animations/scaling.intro.widget.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+const welcomeImage = 'assets/images/hangman-happy.svg';
+
+class ScalingIntroWidget extends StatefulWidget {
+  final Widget child;
+  final void Function()? onAnimationComplete;
+
+  const ScalingIntroWidget({Key? key, required this.child, this.onAnimationComplete}) : super(key: key);
+
+  @override
+  State<ScalingIntroWidget> createState() => _ScalingIntroWidgetState();
+}
+
+class _ScalingIntroWidgetState extends State<ScalingIntroWidget> with SingleTickerProviderStateMixin {
+  late final AnimationController animController;
+  late final Animation<double> scaleAnimation;
+  late final Animation<double> fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    animController = AnimationController(duration: const Duration(milliseconds: 2000), vsync: this);
+    animController.addListener(() {
+      setState(() {});
+    });
+
+    scaleAnimation = TweenSequence(
+      [
+        TweenSequenceItem(tween: Tween<double>(begin: 0, end: 1.25), weight: 1.0),
+        TweenSequenceItem(tween: Tween<double>(begin: 1.25, end: 1.0), weight: 1.0),
+      ],
+    ).animate(CurvedAnimation(parent: animController, curve: const Interval(0, .75)));
+
+    fadeAnimation = Tween<double>(begin: 0, end: 1)
+        .chain(CurveTween(curve: Curves.ease))
+        .animate(CurvedAnimation(parent: animController, curve: const Interval(0, 1)));
+
+    Future.delayed(const Duration(milliseconds: 100), () {
+      animController.forward(from: 0).then((value) {
+        if (widget.onAnimationComplete != null) {
+          widget.onAnimationComplete!();
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    animController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(opacity: fadeAnimation, child: ScaleTransition(scale: scaleAnimation, child: widget.child));
+  }
+}


### PR DESCRIPTION
### Elements addressed by this pull request

- create generic reusable animation (zoom in, fade in)
- use it for generated QR code
- renamed `SlideIntroWidget` to match it's latest behaviour

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android

https://user-images.githubusercontent.com/3459255/173470718-0d588542-d043-43bf-b282-1fa45141019f.mp4

#### iOS (iPhone simulator)

Portrait mode:

https://user-images.githubusercontent.com/3459255/173471957-deb8aa46-ba69-4682-ab81-b5ac2c4e0ae2.mp4

Landscape mode:

https://user-images.githubusercontent.com/3459255/173471463-ec480885-f83f-44bf-b112-9a3211f2281f.mov

