### PR TITLE
fix: safe area on iPhones

### DIFF
--- a/lib/features/game/game.layout.portrait.widget.dart
+++ b/lib/features/game/game.layout.portrait.widget.dart
@@ -13,13 +13,17 @@ class GameLayoutPortraitWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        children: const <Widget>[
-          TextToGuessPanel(),
-          Expanded(child: GameImageWidget()),
-          GameBottomWidget(),
-        ],
+    return SafeArea(
+      top: false,
+      bottom: true,
+      child: Center(
+        child: Column(
+          children: const <Widget>[
+            TextToGuessPanel(),
+            Expanded(child: GameImageWidget()),
+            GameBottomWidget(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Elements addressed by this pull request

- indent the portrait gaming widget by the amount necessary to avoid The Notch on the iPhone X

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

Before | After
------ | ------
![image](https://user-images.githubusercontent.com/3459255/173573019-65a9e357-162a-46db-b1c5-70cdafc9cfbf.png) | ![image](https://user-images.githubusercontent.com/3459255/173572919-c2633f60-64fb-413c-9cd0-d8528ecf3380.png)

Other non-iOS devices remain unaffected:
Android | Webapp
------ | ------
![image](https://user-images.githubusercontent.com/3459255/173573873-7004bb8e-ce30-4c39-855b-830f9d392698.png) | ![image](https://user-images.githubusercontent.com/3459255/173574377-e447104c-ba8e-4061-b23e-1ac9414a51b1.png)
