### PR TITLE
test: add code coverage for Categories screen

### DIFF
--- a/test/features/categories/categories.screen_test.dart
+++ b/test/features/categories/categories.screen_test.dart
@@ -74,4 +74,23 @@ void main() {
     expect(find.text(mockPlanetsCategory.name), findsOneWidget);
     expect(find.text(mockCountriesCategory.name), findsOneWidget);
   });
+
+  testWidgets('Should handle the user choice on press', (WidgetTester tester) async {
+    // given
+    when(mockTextsService.getCategories()).thenAnswer((_) => Future.value(mockCategories));
+    when(mockGameStore.selectCategory(any)).thenAnswer((_) => Future.value(null));
+
+    // test
+    await tester.pumpWidget(wrapper(const CategoriesWidget()));
+    await tester.pump(); // wait for the spinner to disappear
+
+    // when
+    verifyNever(mockGameStore.selectCategory(mockAnimalCategory));
+
+    await tester.tap(find.text(mockAnimalCategory.name));
+    await tester.pump(); // wait for the animation to finish
+
+    // then
+    verify(mockGameStore.selectCategory(mockAnimalCategory)).called(1);
+  });
 }

--- a/test/features/categories/categories.screen_test.dart
+++ b/test/features/categories/categories.screen_test.dart
@@ -29,7 +29,7 @@ void main() {
         GetIt.I.reset(),
       });
 
-  final mockCategories = [mockAnimalCategory, mockTransportCategory];
+  final mockCategories = [mockAnimalCategory, mockTransportCategory, mockColorsCategory, mockUSStatesCategory, mockPlanetsCategory, mockCountriesCategory];
   final spinnerFinder = find.byKey(const Key('categories_loading'));
 
   Widget wrapper(Widget widget) => MaterialApp(
@@ -69,5 +69,9 @@ void main() {
     // then
     expect(find.text(mockAnimalCategory.name), findsOneWidget);
     expect(find.text(mockTransportCategory.name), findsOneWidget);
+    expect(find.text(mockColorsCategory.name), findsOneWidget);
+    expect(find.text(mockUSStatesCategory.name), findsOneWidget);
+    expect(find.text(mockPlanetsCategory.name), findsOneWidget);
+    expect(find.text(mockCountriesCategory.name), findsOneWidget);
   });
 }

--- a/test/mocks/categories.mocks.dart
+++ b/test/mocks/categories.mocks.dart
@@ -9,7 +9,35 @@ final mockAnimalCategory = ApiCategory(
 
 final mockTransportCategory = ApiCategory(
   id: 2,
-  uuid: 'transport-uuid',
+  uuid: 'transports-uuid',
   langCode: 'en',
-  name: 'transport',
+  name: 'transports',
+);
+
+final mockColorsCategory = ApiCategory(
+  id: 3,
+  uuid: 'colors-uuid',
+  langCode: 'en',
+  name: 'colors',
+);
+
+final mockUSStatesCategory = ApiCategory(
+  id: 4,
+  uuid: 'usstates-uuid',
+  langCode: 'en',
+  name: 'U.S state names',
+);
+
+final mockPlanetsCategory = ApiCategory(
+  id: 5,
+  uuid: 'planets-uuid',
+  langCode: 'en',
+  name: 'planets',
+);
+
+final mockCountriesCategory = ApiCategory(
+  id: 6,
+  uuid: 'countries-uuid',
+  langCode: 'en',
+  name: 'countries',
 );


### PR DESCRIPTION
## [Issue 39](https://github.com/amwebexpert/guess_the_text/issues/39)
This fixes #39

### Elements addressed by this pull request
Test following elements for the categories screen:
- display available categories
- handle the user choice on press

### Checklist

- [x] Unit tests completed
- [ ] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos
Tests passing successfully:
![image](https://user-images.githubusercontent.com/13435783/173799679-1de2ec26-a9f0-46ab-afd6-d80cf5e461d7.png)

Full test coverage for category.widget.dart
![image](https://user-images.githubusercontent.com/13435783/173800133-da496323-48d7-427a-a1c5-9249d38e4337.png)