### PR TITLE
feat: responsive layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Free mobile application originally created to learn the `Flutter` framework in m
 
 The goal is to learn a technology at the same time as providing a fun and scalable educational tool. The source code of this application is available and may also serve as a learning base for training sessions in `Dart` programming with `Flutter`!
 
-## Deployed on production:
+## Some screen captures of the implemented features
+
+success | failure | custom chalenge | qr-code
+------- | ---------- | ---------- | ----------
+<img src="store-presence/guess-the-text-03.png" /> | <img src="store-presence/guess-the-text-04.png" /> | <img src="store-presence/create-a-challenge.jpg" /> | <img src="store-presence/qr-code-display.jpg" />
+
+
+## Deployed on production
 
 - [Google Play](https://play.google.com/store/apps/details?id=com.amwebexpert.app.guessthetext.guess_the_text)
 - App Store

--- a/lib/features/game/game.image.intro.widget.dart
+++ b/lib/features/game/game.image.intro.widget.dart
@@ -51,6 +51,12 @@ class _GameImageIntroWidgetState extends State<GameImageIntroWidget> with Single
   @override
   Widget build(BuildContext context) {
     return FadeTransition(
-        opacity: fadeAnimation, child: ScaleTransition(scale: scaleAnimation, child: SvgPicture.asset(welcomeImage)));
+        opacity: fadeAnimation,
+        child: ScaleTransition(
+            scale: scaleAnimation,
+            child: SvgPicture.asset(
+              welcomeImage,
+              fit: BoxFit.fill,
+            )));
   }
 }

--- a/lib/features/game/game.image.widget.dart
+++ b/lib/features/game/game.image.widget.dart
@@ -26,12 +26,15 @@ class _GameImageWidgetState extends State<GameImageWidget> with SingleTickerProv
   @override
   Widget build(BuildContext context) {
     return Observer(builder: (BuildContext context) {
-      return isIntroAnimation
-          ? GameImageIntroWidget(onAnimationComplete: onAnimationComplete)
-          : SvgPicture.asset(
-              gameStore.currentStateImg,
-              fit: BoxFit.fill,
-            );
+      return Column(
+        children: [
+          Expanded(
+            child: isIntroAnimation
+                ? GameImageIntroWidget(onAnimationComplete: onAnimationComplete)
+                : SvgPicture.asset(gameStore.currentStateImg, fit: BoxFit.fill),
+          ),
+        ],
+      );
     });
   }
 }

--- a/lib/features/game/game.image.widget.dart
+++ b/lib/features/game/game.image.widget.dart
@@ -28,7 +28,10 @@ class _GameImageWidgetState extends State<GameImageWidget> with SingleTickerProv
     return Observer(builder: (BuildContext context) {
       return isIntroAnimation
           ? GameImageIntroWidget(onAnimationComplete: onAnimationComplete)
-          : SvgPicture.asset(gameStore.currentStateImg);
+          : SvgPicture.asset(
+              gameStore.currentStateImg,
+              fit: BoxFit.fill,
+            );
     });
   }
 }

--- a/lib/features/game/game.interaction.panel.widget.dart
+++ b/lib/features/game/game.interaction.panel.widget.dart
@@ -5,8 +5,8 @@ import 'package:guess_the_text/features/game/game.session.conclusion.widget.dart
 import 'package:guess_the_text/features/game/game.store.dart';
 import 'package:guess_the_text/service.locator.dart';
 
-class GameBottomWidget extends StatelessWidget {
-  const GameBottomWidget({Key? key}) : super(key: key);
+class GameInteractionPanelWidget extends StatelessWidget {
+  const GameInteractionPanelWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -2,16 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:guess_the_text/features/game/game.image.widget.dart';
 import 'package:guess_the_text/features/game/game.interaction.panel.widget.dart';
 import 'package:guess_the_text/features/game/text.and.category.widget.dart';
+import 'package:responsive_framework/responsive_framework.dart';
 
 class GameLayoutLandscapeWidget extends StatelessWidget {
   const GameLayoutLandscapeWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final leftFlexWeight = ResponsiveValue(
+      context,
+      defaultValue: 1,
+      valueWhen: const [Condition.largerThan(name: TABLET, value: 1)],
+    ).value!;
+    final rightFlexWeight = ResponsiveValue(
+      context,
+      defaultValue: 1,
+      valueWhen: const [Condition.largerThan(name: TABLET, value: 2)],
+    ).value!;
+
     return Row(
-      children: const <Widget>[
-        Flexible(flex: 1, child: TextAndKeyboardWidget()),
-        Flexible(flex: 1, child: GameImageWidget()),
+      children: <Widget>[
+        Flexible(flex: leftFlexWeight, child: const TextAndKeyboardWidget()),
+        Flexible(flex: rightFlexWeight, child: const GameImageWidget()),
       ],
     );
   }

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -10,8 +10,8 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: const <Widget>[
-        Flexible(flex: 3, child: TextAndKeyboardWidget()),
-        Flexible(flex: 4, child: GameImageWidget()),
+        Flexible(flex: 1, child: TextAndKeyboardWidget()),
+        Flexible(flex: 1, child: GameImageWidget()),
       ],
     );
   }
@@ -27,7 +27,7 @@ class TextAndKeyboardWidget extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: const [
           TextAndCategoryWidget(),
-          GameBottomWidget(),
+          GameInteractionPanelWidget(),
         ],
       ),
     );

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:guess_the_text/features/game/game.image.widget.dart';
 import 'package:guess_the_text/features/game/game.interaction.panel.widget.dart';
-import 'package:guess_the_text/features/game/game.store.dart';
-import 'package:guess_the_text/features/game/text_to_guess/text.to.guess.widget.dart';
-import 'package:guess_the_text/features/game/category.widget.dart';
-import 'package:guess_the_text/service.locator.dart';
-import 'package:guess_the_text/store/fixed.delay.spinner.store.dart';
+import 'package:guess_the_text/features/game/text.and.category.widget.dart';
 
 class GameLayoutLandscapeWidget extends StatelessWidget {
   const GameLayoutLandscapeWidget({Key? key}) : super(key: key);
@@ -15,46 +10,20 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        const TextToGuessPanel(),
+        const TextAndCategoryWidget(),
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: const <Widget>[
-                Flexible(flex: 3, child: GameBottomWidget()),
-                Flexible(flex: 2, child: GameImageWidget()),
+                Flexible(flex: 1, child: GameBottomWidget()),
+                Flexible(flex: 1, child: GameImageWidget()),
               ],
             ),
           ),
         ),
       ],
     );
-  }
-}
-
-class TextToGuessPanel extends StatelessWidget {
-  const TextToGuessPanel({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final GameStore gameStore = serviceLocator.get();
-    final FixedDelaySpinnerStore spinnerStore = serviceLocator.get();
-
-    return Observer(builder: (BuildContext context) {
-      if (spinnerStore.isLoading) {
-        return TextToGuessWidget(
-            text: gameStore.textToGuess.wordGame(), isAnimated: false, isLoading: spinnerStore.isLoading);
-      }
-
-      return Row(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
-        children: [
-          TextToGuessWidget(
-              text: gameStore.textToGuess.wordGame(), isAnimated: false, isLoading: spinnerStore.isLoading),
-          const CategoryWidget(),
-        ],
-      );
-    });
   }
 }

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -8,22 +8,28 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        const TextAndCategoryWidget(),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: const <Widget>[
-                Flexible(flex: 1, child: GameBottomWidget()),
-                Flexible(flex: 1, child: GameImageWidget()),
-              ],
-            ),
-          ),
-        ),
+    return Row(
+      children: const <Widget>[
+        Flexible(flex: 3, child: TextAndKeyboardWidget()),
+        Flexible(flex: 4, child: GameImageWidget()),
       ],
+    );
+  }
+}
+
+class TextAndKeyboardWidget extends StatelessWidget {
+  const TextAndKeyboardWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          TextAndCategoryWidget(),
+          GameBottomWidget(),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/game/game.layout.portrait.widget.dart
+++ b/lib/features/game/game.layout.portrait.widget.dart
@@ -16,7 +16,7 @@ class GameLayoutPortraitWidget extends StatelessWidget {
           children: const <Widget>[
             TextAndCategoryWidget(),
             Expanded(child: GameImageWidget()),
-            GameBottomWidget(),
+            GameInteractionPanelWidget(),
           ],
         ),
       ),

--- a/lib/features/game/game.layout.portrait.widget.dart
+++ b/lib/features/game/game.layout.portrait.widget.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:guess_the_text/features/game/game.image.widget.dart';
 import 'package:guess_the_text/features/game/game.interaction.panel.widget.dart';
-import 'package:guess_the_text/features/game/game.store.dart';
-import 'package:guess_the_text/features/game/text_to_guess/text.to.guess.widget.dart';
-import 'package:guess_the_text/features/game/category.widget.dart';
-import 'package:guess_the_text/service.locator.dart';
-import 'package:guess_the_text/store/fixed.delay.spinner.store.dart';
+import 'package:guess_the_text/features/game/text.and.category.widget.dart';
 
 class GameLayoutPortraitWidget extends StatelessWidget {
   const GameLayoutPortraitWidget({Key? key}) : super(key: key);
@@ -19,32 +14,12 @@ class GameLayoutPortraitWidget extends StatelessWidget {
       child: Center(
         child: Column(
           children: const <Widget>[
-            TextToGuessPanel(),
+            TextAndCategoryWidget(),
             Expanded(child: GameImageWidget()),
             GameBottomWidget(),
           ],
         ),
       ),
     );
-  }
-}
-
-class TextToGuessPanel extends StatelessWidget {
-  const TextToGuessPanel({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final GameStore gameStore = serviceLocator.get();
-    final FixedDelaySpinnerStore spinnerStore = serviceLocator.get();
-
-    return Observer(builder: (BuildContext context) {
-      return Column(
-        children: [
-          const CategoryWidget(),
-          TextToGuessWidget(
-              text: gameStore.textToGuess.wordGame(), isAnimated: false, isLoading: spinnerStore.isLoading),
-        ],
-      );
-    });
   }
 }

--- a/lib/features/game/text.and.category.widget.dart
+++ b/lib/features/game/text.and.category.widget.dart
@@ -14,23 +14,21 @@ class TextAndCategoryWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final GameStore gameStore = serviceLocator.get();
     final FixedDelaySpinnerStore spinnerStore = serviceLocator.get();
+    final isColumnLayout = ResponsiveWrapper.of(context).isSmallerThan(MOBILE) ||
+        ResponsiveWrapper.of(context).orientation == Orientation.landscape;
 
     return Observer(builder: (BuildContext context) {
+      final text = gameStore.textToGuess.wordGame();
+
       return ResponsiveRowColumn(
         rowMainAxisAlignment: MainAxisAlignment.spaceAround,
-        layout: ResponsiveWrapper.of(context).isSmallerThan(MOBILE)
-            ? ResponsiveRowColumnType.COLUMN
-            : ResponsiveRowColumnType.ROW,
+        layout: isColumnLayout ? ResponsiveRowColumnType.COLUMN : ResponsiveRowColumnType.ROW,
         children: [
           ResponsiveRowColumnItem(
             rowFlex: 1,
-            child: TextToGuessWidget(
-                text: gameStore.textToGuess.wordGame(), isAnimated: false, isLoading: spinnerStore.isLoading),
+            child: TextToGuessWidget(text: text, isAnimated: false, isLoading: spinnerStore.isLoading),
           ),
-          const ResponsiveRowColumnItem(
-            rowFlex: 1,
-            child: CategoryWidget(),
-          ),
+          const ResponsiveRowColumnItem(rowFlex: 1, child: CategoryWidget()),
         ],
       );
     });

--- a/lib/features/game/text.and.category.widget.dart
+++ b/lib/features/game/text.and.category.widget.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:guess_the_text/features/game/category.widget.dart';
+import 'package:guess_the_text/features/game/game.store.dart';
+import 'package:guess_the_text/features/game/text_to_guess/text.to.guess.widget.dart';
+import 'package:guess_the_text/service.locator.dart';
+import 'package:guess_the_text/store/fixed.delay.spinner.store.dart';
+import 'package:responsive_framework/responsive_framework.dart';
+
+class TextAndCategoryWidget extends StatelessWidget {
+  const TextAndCategoryWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final GameStore gameStore = serviceLocator.get();
+    final FixedDelaySpinnerStore spinnerStore = serviceLocator.get();
+
+    return Observer(builder: (BuildContext context) {
+      return ResponsiveRowColumn(
+        rowMainAxisAlignment: MainAxisAlignment.spaceAround,
+        layout: ResponsiveWrapper.of(context).isSmallerThan(MOBILE)
+            ? ResponsiveRowColumnType.COLUMN
+            : ResponsiveRowColumnType.ROW,
+        children: [
+          ResponsiveRowColumnItem(
+            rowFlex: 1,
+            child: TextToGuessWidget(
+                text: gameStore.textToGuess.wordGame(), isAnimated: false, isLoading: spinnerStore.isLoading),
+          ),
+          const ResponsiveRowColumnItem(
+            rowFlex: 1,
+            child: CategoryWidget(),
+          ),
+        ],
+      );
+    });
+  }
+}

--- a/lib/features/settings/hero.settings.widget.dart
+++ b/lib/features/settings/hero.settings.widget.dart
@@ -15,7 +15,7 @@ class HeroSettingsWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Hero(
-      tag: 'preferences',
+      tag: 'app-menu-item-preferences',
       child: buildIcon(context),
       placeholderBuilder: (context, size, child) => buildIcon(context, colorAlpha: 0.70),
       flightShuttleBuilder: (

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:guess_the_text/theme/app.theme.dart';
 import 'package:guess_the_text/utils/animation.utils.dart';
 import 'package:guess_the_text/utils/randomizer.utils.dart';
 import 'package:lottie/lottie.dart';
+import 'package:responsive_framework/responsive_framework.dart';
 
 void main() {
   if (!kDebugMode) {
@@ -74,6 +75,15 @@ class _HangmanAppState extends State<HangmanApp> {
         themeMode: settingsStore.isDarkTheme ? ThemeMode.dark : ThemeMode.light,
         initialRoute: '/',
         onGenerateRoute: onGenerateRoute,
+        builder: (context, widget) => ResponsiveWrapper.builder(
+          ClampingScrollWrapper.builder(context, widget!),
+          maxWidth: 1200,
+          breakpoints: const [
+            ResponsiveBreakpoint.resize(576, name: MOBILE),
+            ResponsiveBreakpoint.resize(768, name: TABLET),
+            ResponsiveBreakpoint.resize(992, name: DESKTOP),
+          ],
+        ),
       );
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,7 @@ class _HangmanAppState extends State<HangmanApp> {
         builder: (context, widget) => ResponsiveWrapper.builder(
           ClampingScrollWrapper.builder(context, widget!),
           maxWidth: 1200,
+          backgroundColor: Colors.black,
           breakpoints: const [
             ResponsiveBreakpoint.resize(576, name: MOBILE),
             ResponsiveBreakpoint.resize(768, name: TABLET),

--- a/lib/theme/widgets/app.menu.item.widget.dart
+++ b/lib/theme/widgets/app.menu.item.widget.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:guess_the_text/utils/icon.utils.dart';
+
+class MenuItemWidget extends StatelessWidget {
+  const MenuItemWidget({Key? key, required this.titleLabel, required this.iconName, required this.onTap})
+      : super(key: key);
+
+  final String titleLabel;
+  final String iconName;
+  final Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      leading: Hero(
+        tag: 'app-menu-item-$iconName',
+        child: Icon(iconsMap[iconName]),
+      ),
+      title: Text(titleLabel),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -17,95 +17,90 @@ class AppMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Drawer(
-      // Add a ListView to the drawer. This ensures the user can scroll
-      // through the options in the drawer if there isn't enough vertical
-      // space to fit everything.
-      child: ListView(
-        // Important: Remove any padding from the ListView.
-        padding: EdgeInsets.zero,
-        shrinkWrap: true,
-        children: [
-          const MenuLogo(),
-          ListTile(
-            visualDensity: VisualDensity.compact,
-            leading: Icon(
-              iconsMap['categories'],
+    return ListView(
+      // Important: Remove any padding from the ListView.
+      padding: EdgeInsets.zero,
+      shrinkWrap: true,
+      children: [
+        const MenuLogo(),
+        ListTile(
+          visualDensity: VisualDensity.compact,
+          leading: Icon(
+            iconsMap['categories'],
+          ),
+          title: Text(localizations.categories, style: Theme.of(context).textTheme.bodyText1),
+          onTap: () {
+            Navigator.pop(context);
+            Navigator.pushNamed(context, '/categories');
+          },
+        ),
+        const Divider(
+          thickness: 2,
+        ),
+        ListTile(
+          visualDensity: VisualDensity.compact,
+          leading: Icon(
+            iconsMap['adhoc'],
+          ),
+          title: Text(localizations.adhocText, style: Theme.of(context).textTheme.bodyText1),
+          onTap: () {
+            Navigator.pop(context);
+            onCreateChallengePress();
+          },
+        ),
+        const Divider(
+          thickness: 2,
+        ),
+        ListTile(
+          visualDensity: VisualDensity.compact,
+          leading: Icon(
+            iconsMap['adhocScan'],
+          ),
+          title: Text(localizations.appMenuReadChalenge, style: Theme.of(context).textTheme.bodyText1),
+          onTap: () {
+            Navigator.pop(context);
+            onAcceptChallengePress();
+          },
+        ),
+        const Divider(
+          thickness: 2,
+        ),
+        ListTile(
+          visualDensity: VisualDensity.compact,
+          leading: Hero(
+            tag: 'preferences',
+            child: Icon(
+              iconsMap['preferences'],
             ),
-            title: Text(localizations.categories, style: Theme.of(context).textTheme.bodyText1),
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.pushNamed(context, '/categories');
-            },
           ),
-          const Divider(
-            thickness: 2,
+          title: Text(
+            localizations.preferences,
           ),
-          ListTile(
-            visualDensity: VisualDensity.compact,
-            leading: Icon(
-              iconsMap['adhoc'],
-            ),
-            title: Text(localizations.adhocText, style: Theme.of(context).textTheme.bodyText1),
-            onTap: () {
-              Navigator.pop(context);
-              onCreateChallengePress();
-            },
+          onTap: () {
+            Navigator.pop(context);
+            Navigator.pushNamed(context, '/settings');
+          },
+        ),
+        const Divider(
+          thickness: 2,
+        ),
+        ListTile(
+          visualDensity: VisualDensity.compact,
+          leading: Icon(
+            iconsMap['info'],
           ),
-          const Divider(
-            thickness: 2,
+          title: Text(
+            localizations.about,
           ),
-          ListTile(
-            visualDensity: VisualDensity.compact,
-            leading: Icon(
-              iconsMap['adhocScan'],
-            ),
-            title: Text(localizations.appMenuReadChalenge, style: Theme.of(context).textTheme.bodyText1),
-            onTap: () {
-              Navigator.pop(context);
-              onAcceptChallengePress();
-            },
-          ),
-          const Divider(
-            thickness: 2,
-          ),
-          ListTile(
-            visualDensity: VisualDensity.compact,
-            leading: Hero(
-              tag: 'preferences',
-              child: Icon(
-                iconsMap['preferences'],
-              ),
-            ),
-            title: Text(
-              localizations.preferences,
-            ),
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.pushNamed(context, '/settings');
-            },
-          ),
-          const Divider(
-            thickness: 2,
-          ),
-          ListTile(
-            visualDensity: VisualDensity.compact,
-            leading: Icon(
-              iconsMap['info'],
-            ),
-            title: Text(
-              localizations.about,
-            ),
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.pushNamed(context, '/about');
-            },
-          ),
-          const Divider(
-            thickness: 2,
-          ),
-        ],
-      ),
+          onTap: () {
+            Navigator.pop(context);
+            Navigator.pushNamed(context, '/about');
+          },
+        ),
+        const Divider(
+          thickness: 2,
+        ),
+      ],
     );
   }
 }

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:guess_the_text/utils/icon.utils.dart';
+import 'package:guess_the_text/theme/widgets/app.menu.item.widget.dart';
 import 'package:guess_the_text/theme/widgets/menu.logo.widget.dart';
 
 class AppMenu extends StatelessWidget {
@@ -23,83 +23,51 @@ class AppMenu extends StatelessWidget {
       shrinkWrap: true,
       children: [
         const MenuLogo(),
-        ListTile(
-          visualDensity: VisualDensity.compact,
-          leading: Icon(
-            iconsMap['categories'],
-          ),
-          title: Text(localizations.categories),
+        MenuItemWidget(
+          titleLabel: localizations.categories,
+          iconName: 'categories',
           onTap: () {
             Navigator.pop(context);
             Navigator.pushNamed(context, '/categories');
           },
         ),
-        const Divider(
-          thickness: 2,
-        ),
-        ListTile(
-          visualDensity: VisualDensity.compact,
-          leading: Icon(
-            iconsMap['adhoc'],
-          ),
-          title: Text(localizations.adhocText),
+        const Divider(thickness: 2),
+        MenuItemWidget(
+          titleLabel: localizations.adhocText,
+          iconName: 'adhoc',
           onTap: () {
             Navigator.pop(context);
             onCreateChallengePress();
           },
         ),
-        const Divider(
-          thickness: 2,
-        ),
-        ListTile(
-          visualDensity: VisualDensity.compact,
-          leading: Icon(
-            iconsMap['adhocScan'],
-          ),
-          title: Text(localizations.appMenuReadChalenge),
+        const Divider(thickness: 2),
+        MenuItemWidget(
+          titleLabel: localizations.appMenuReadChalenge,
+          iconName: 'adhocScan',
           onTap: () {
             Navigator.pop(context);
             onAcceptChallengePress();
           },
         ),
-        const Divider(
-          thickness: 2,
-        ),
-        ListTile(
-          visualDensity: VisualDensity.compact,
-          leading: Hero(
-            tag: 'preferences',
-            child: Icon(
-              iconsMap['preferences'],
-            ),
-          ),
-          title: Text(
-            localizations.preferences,
-          ),
+        const Divider(thickness: 2),
+        MenuItemWidget(
+          titleLabel: localizations.preferences,
+          iconName: 'preferences',
           onTap: () {
             Navigator.pop(context);
             Navigator.pushNamed(context, '/settings');
           },
         ),
-        const Divider(
-          thickness: 2,
-        ),
-        ListTile(
-          visualDensity: VisualDensity.compact,
-          leading: Icon(
-            iconsMap['info'],
-          ),
-          title: Text(
-            localizations.about,
-          ),
+        const Divider(thickness: 2),
+        MenuItemWidget(
+          titleLabel: localizations.about,
+          iconName: 'info',
           onTap: () {
             Navigator.pop(context);
             Navigator.pushNamed(context, '/about');
           },
         ),
-        const Divider(
-          thickness: 2,
-        ),
+        const Divider(thickness: 2),
       ],
     );
   }

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -28,7 +28,7 @@ class AppMenu extends StatelessWidget {
           leading: Icon(
             iconsMap['categories'],
           ),
-          title: Text(localizations.categories, style: Theme.of(context).textTheme.bodyText1),
+          title: Text(localizations.categories),
           onTap: () {
             Navigator.pop(context);
             Navigator.pushNamed(context, '/categories');
@@ -42,7 +42,7 @@ class AppMenu extends StatelessWidget {
           leading: Icon(
             iconsMap['adhoc'],
           ),
-          title: Text(localizations.adhocText, style: Theme.of(context).textTheme.bodyText1),
+          title: Text(localizations.adhocText),
           onTap: () {
             Navigator.pop(context);
             onCreateChallengePress();
@@ -56,7 +56,7 @@ class AppMenu extends StatelessWidget {
           leading: Icon(
             iconsMap['adhocScan'],
           ),
-          title: Text(localizations.appMenuReadChalenge, style: Theme.of(context).textTheme.bodyText1),
+          title: Text(localizations.appMenuReadChalenge),
           onTap: () {
             Navigator.pop(context);
             onAcceptChallengePress();

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -20,7 +20,6 @@ class AppMenu extends StatelessWidget {
     return ListView(
       // Important: Remove any padding from the ListView.
       padding: EdgeInsets.zero,
-      shrinkWrap: true,
       children: [
         const MenuLogo(),
         MenuItemWidget(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -687,6 +687,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  responsive_framework:
+    dependency: "direct main"
+    description:
+      name: responsive_framework
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   sembast:
     dependency: "direct main"
     description:
@@ -988,4 +995,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.17.0 <3.0.0"
-  flutter: ">=2.11.0-0.1.pre"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   path: ^1.8.1
   sembast_web: ^2.0.1+1
   universal_io: ^2.0.4
+  responsive_framework: ^0.2.0
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
## [Issue 32](https://github.com/amwebexpert/guess_the_text/issues/32)

### Elements addressed by this pull request

- game image stretching
- added responsive breakpoints
- improved landscape left and right side flex weight depending on breakpoints
- generic `TextAndCategoryWidget` displayed as `row` / `column` depending on breakpoints
- refactoring to apply `DRY` rule on drawer menu
- improved `README.md` by adding 4 screens captures

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android
Portrait | Landscape
------- | -----------
![image](https://user-images.githubusercontent.com/3459255/174415068-3f58083e-2945-4b29-8ea3-fb09655b8db2.png) | ![image](https://user-images.githubusercontent.com/3459255/174415058-6ec6ce2b-f1a4-4780-ad7f-236e4becebf2.png)


#### web
Portrait | Landscape
------- | -----------
<img width="772" alt="image" src="https://user-images.githubusercontent.com/3459255/174414518-af5c3f37-0efb-4998-9eb2-da9df76aacc1.png"> | <img width="772" alt="image" src="https://user-images.githubusercontent.com/3459255/174414576-74329bb3-dbba-42bb-85cc-8ceb9d038e78.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/3459255/174414686-820eed19-6ca1-48c0-8221-b15448af261d.png"> | <img width="809" alt="image" src="https://user-images.githubusercontent.com/3459255/174414709-6893a2ef-252b-4e1d-b884-67d1afc479cb.png">


#### Live responsive

https://user-images.githubusercontent.com/3459255/174414870-819cf38f-6fb7-4fdd-b31b-f3a2c87bc5e1.mov


