### PR TITLE
feat: device screen dimensions info

### DIFF
--- a/lib/features/about/card.widget.dart
+++ b/lib/features/about/card.widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:guess_the_text/features/about/card.app.description.dart';
 import 'package:guess_the_text/features/about/card.header.animation.widget.dart';
 import 'package:guess_the_text/features/about/card.header.widget.dart';
+import 'package:guess_the_text/features/about/platform.screen.info.table.widget.dart';
 import 'package:guess_the_text/features/about/privacy.policy.widget.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
 
@@ -36,6 +37,10 @@ class AboutCard extends StatelessWidget {
                 Padding(
                   padding: EdgeInsets.all(spacing(1)),
                   child: const PlatformInfoTable(),
+                ),
+                Padding(
+                  padding: EdgeInsets.all(spacing(1)),
+                  child: const PlatformScreenInfoTable(),
                 ),
               ],
             ),

--- a/lib/features/about/platform.screen.info.table.widget.dart
+++ b/lib/features/about/platform.screen.info.table.widget.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:responsive_framework/responsive_framework.dart';
+
+class PlatformScreenInfoTable extends StatelessWidget {
+  const PlatformScreenInfoTable({Key? key}) : super(key: key);
+
+  String getScreenType(BuildContext context) => ResponsiveValue(
+        context,
+        // TODO Localize me
+        defaultValue: 'MOBILE',
+        valueWhen: const [
+          Condition.equals(name: TABLET, value: 'TABLET'),
+          Condition.equals(name: DESKTOP, value: 'DESKTOP')
+        ],
+      ).value!;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenType = getScreenType(context);
+    final screen = MediaQuery.of(context);
+
+    return Column(
+      children: [
+        Text(
+          'Screen specifications', // TODO Localize me
+          style: Theme.of(context).textTheme.bodyText2,
+        ),
+        DataTable(
+          horizontalMargin: 0,
+          columnSpacing: 16,
+          headingRowHeight: 20,
+          dataRowHeight: 24,
+          columns: const <DataColumn>[DataColumn(label: Text('')), DataColumn(label: Text(''))],
+          // TODO Localize me (all rows)
+          rows: <DataRow>[
+            DataRow(cells: <DataCell>[const DataCell(Text('Type')), DataCell(Text(screenType))]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Width')),
+              DataCell(Text('${screen.size.width.toInt()} pixels'))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Height')),
+              DataCell(Text('${screen.size.height.toInt()} pixels'))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Pixel ratio')),
+              DataCell(Text(screen.devicePixelRatio.toString()))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Orientation')),
+              DataCell(Text(screen.orientation.name.toString()))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Text scale factor')),
+              DataCell(Text(screen.textScaleFactor.toString()))
+            ]),
+          ],
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## [Issue 52](https://github.com/amwebexpert/guess_the_text/issues/52)

### Elements addressed by this pull request

added info:

* width and height
* portrait / landscape detected mode
* pixel ratio
* text scaling factor

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

Android | Webapp | iPhone
-------- | -------- | --------
![demo-android-screen-specifications](https://user-images.githubusercontent.com/3459255/174499737-2a69bd6d-9401-4a62-a247-21e7173aa1a9.png) | <img width="1674" alt="demo-web-screen-specifications" src="https://user-images.githubusercontent.com/3459255/174499739-5382454b-1a89-47d8-b231-22625152df3d.png"> | <img width="467" alt="demo-ios-screen-specifications" src="https://user-images.githubusercontent.com/3459255/174499744-f391fef0-c303-412c-bc4e-8ad41088e881.png">

