### PR TITLE
feat: animate only the pressed letter

### DIFF
--- a/lib/features/game/letter.widget.dart
+++ b/lib/features/game/letter.widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class LetterWidget extends StatelessWidget {
+class LetterWidget extends StatefulWidget {
   final void Function(String c) onLetterPressed;
   final String letter;
   final bool isButtonEnable;
@@ -9,13 +9,58 @@ class LetterWidget extends StatelessWidget {
       : super(key: key);
 
   @override
+  State<LetterWidget> createState() => _LetterWidgetState();
+}
+
+class _LetterWidgetState extends State<LetterWidget> with SingleTickerProviderStateMixin {
+  late final AnimationController animController;
+  late final Animation<double> rotationAnim;
+  late final Animation<double> scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    animController = AnimationController(duration: const Duration(seconds: 1), vsync: this);
+    animController.addListener(() {
+      setState(() {});
+    });
+
+    rotationAnim = Tween<double>(begin: 0.0, end: 1.0).chain(CurveTween(curve: Curves.ease)).animate(animController);
+
+    scaleAnimation = TweenSequence(
+      [
+        TweenSequenceItem(tween: Tween<double>(begin: 1, end: 2), weight: 1.0),
+        TweenSequenceItem(tween: Tween<double>(begin: 2, end: 1.0), weight: 1.0),
+      ],
+    ).animate(CurvedAnimation(parent: animController, curve: const Interval(0, .75)));
+  }
+
+  @override
+  void dispose() {
+    animController.dispose();
+    super.dispose();
+  }
+
+  Future<void> onPressed() async {
+    await animController.forward(from: 0);
+    widget.onLetterPressed(widget.letter);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      key: Key('button_$letter'),
-      onPressed: isButtonEnable ? () => onLetterPressed(letter) : null,
-      child: Text(
-        letter,
-        style: Theme.of(context).textTheme.bodyText1?.apply(color: Colors.white),
+    return ScaleTransition(
+      scale: scaleAnimation,
+      child: RotationTransition(
+        turns: rotationAnim,
+        child: ElevatedButton(
+          key: Key('button_${widget.letter}'),
+          onPressed: widget.isButtonEnable ? () => onPressed() : null,
+          child: Text(
+            widget.letter,
+            style: Theme.of(context).textTheme.bodyText1?.apply(color: Colors.white),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/game/letters.widget.dart
+++ b/lib/features/game/letters.widget.dart
@@ -95,7 +95,6 @@ class _LettersWidgetState extends State<LettersWidget> with SingleTickerProvider
   }
 
   void onPressed(String c) {
-    animController.forward(from: 0);
     widget.onLetterPressed(c);
   }
 
@@ -104,7 +103,9 @@ class _LettersWidgetState extends State<LettersWidget> with SingleTickerProvider
     return Wrap(
       direction: Axis.horizontal,
       alignment: WrapAlignment.center,
+      runAlignment: WrapAlignment.center,
       spacing: 1,
+      runSpacing: 1,
       children: LettersWidget.letters
           .map(
             (c) => RotationTransition(


### PR DESCRIPTION
### Elements addressed by this pull request

- only animate the pressed letter instead of the whole keyboard
- specify vertical padding of the wrapped letter buttons

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Web

https://user-images.githubusercontent.com/3459255/174502537-d721b296-aa8c-488b-b5bf-f12b751c9821.mov

#### Android

https://user-images.githubusercontent.com/3459255/174502595-5cdd5167-8c79-49dd-aa49-5b80867c914d.mp4


