### PR TITLE
feat: physical device dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ success | failure | custom chalenge | qr-code
 - [Privacy Policy](https://amw-hangman-api.herokuapp.com/privacy-policy.html)
 - [Webapp demo](https://amwebexpert.github.io/guess_the_text/)
 
+## Coding standards
+
+Guidelines for developers
+
+* [Structure and naming](./naming.md)
+* [Coding patterns](./patterns.md)
+* [Store](./store.md)
+* [Tests](./tests.md)
 
 ## BE Api (deployed on Heroku)
 
@@ -166,7 +174,6 @@ From there, just run the `guess_the_text` executable to run the build!
     flutter devices
     flutter run -d "iPhone 13"
     flutter run -d "SM A505W"
-
 
 ## Usefull references
 

--- a/docs/coding-standards/README.md
+++ b/docs/coding-standards/README.md
@@ -1,0 +1,8 @@
+# Coding standards
+
+Guidelines for developers
+
+* [Structure and naming](./naming.md)
+* [Coding patterns](./patterns.md)
+* [Store](./store.md)
+* [Tests](./tests.md)

--- a/docs/coding-standards/README.md
+++ b/docs/coding-standards/README.md
@@ -1,8 +1,0 @@
-# Coding standards
-
-Guidelines for developers
-
-* [Structure and naming](./naming.md)
-* [Coding patterns](./patterns.md)
-* [Store](./store.md)
-* [Tests](./tests.md)

--- a/docs/coding-standards/naming.md
+++ b/docs/coding-standards/naming.md
@@ -1,0 +1,3 @@
+# Structure and naming conventions
+
+To be documented

--- a/docs/coding-standards/patterns.md
+++ b/docs/coding-standards/patterns.md
@@ -1,0 +1,25 @@
+# React Components
+
+## Theme primary color usage
+
+Prefer using `Theme.of(context).colorScheme.xxxxxx` for theme related colors
+
+#### :x: Avoid
+
+```dart
+return FloatingActionButton(
+      onPressed: onPressed,
+      backgroundColor: Colors.orange.withOpacity(fadingAnim.value),
+      child: const MyChild(),
+);
+```
+
+#### :white_check_mark: Prefer
+
+```dart
+return FloatingActionButton(
+      onPressed: onPressed,
+      backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(fadingAnim.value),
+      child: const MyChild(),
+);
+```

--- a/docs/coding-standards/patterns.md
+++ b/docs/coding-standards/patterns.md
@@ -4,7 +4,7 @@
 
 Prefer using `Theme.of(context).colorScheme.xxxxxx` for theme related colors
 
-#### :x: Avoid
+#### :x: avoid
 
 ```dart
 return FloatingActionButton(
@@ -14,7 +14,7 @@ return FloatingActionButton(
 );
 ```
 
-#### :white_check_mark: Prefer
+#### :green_check_mark: prefer
 
 ```dart
 return FloatingActionButton(

--- a/docs/coding-standards/patterns.md
+++ b/docs/coding-standards/patterns.md
@@ -14,7 +14,7 @@ return FloatingActionButton(
 );
 ```
 
-#### :green_check_mark: prefer
+#### :green_check: prefer
 
 ```dart
 return FloatingActionButton(

--- a/docs/coding-standards/patterns.md
+++ b/docs/coding-standards/patterns.md
@@ -14,7 +14,7 @@ return FloatingActionButton(
 );
 ```
 
-#### :green_check: prefer
+#### :heavy_check_mark: prefer
 
 ```dart
 return FloatingActionButton(

--- a/docs/coding-standards/patterns.md
+++ b/docs/coding-standards/patterns.md
@@ -7,7 +7,7 @@ Prefer using `Theme.of(context).colorScheme.xxxxxx` for theme related colors
 #### :x: avoid
 
 ```dart
-return FloatingActionButton(
+FloatingActionButton(
       onPressed: onPressed,
       backgroundColor: Colors.orange.withOpacity(fadingAnim.value),
       child: const MyChild(),
@@ -17,7 +17,7 @@ return FloatingActionButton(
 #### :heavy_check_mark: prefer
 
 ```dart
-return FloatingActionButton(
+FloatingActionButton(
       onPressed: onPressed,
       backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(fadingAnim.value),
       child: const MyChild(),

--- a/docs/coding-standards/store.md
+++ b/docs/coding-standards/store.md
@@ -1,0 +1,3 @@
+# Store
+
+To be documented

--- a/docs/coding-standards/tests.md
+++ b/docs/coding-standards/tests.md
@@ -1,0 +1,3 @@
+# Tests
+
+To be documented

--- a/lib/features/about/card.header.widget.dart
+++ b/lib/features/about/card.header.widget.dart
@@ -40,10 +40,10 @@ class HeaderlineWidget extends StatelessWidget {
             decorationThickness: 1,
             decorationStyle: TextDecorationStyle.dotted,
             shadows: [
-              const Shadow(
-                color: Colors.orange,
+              Shadow(
+                color: Theme.of(context).colorScheme.primary,
                 blurRadius: 2,
-                offset: Offset(1, 1),
+                offset: const Offset(1, 1),
               ),
             ],
           ),

--- a/lib/features/about/card.header.widget.dart
+++ b/lib/features/about/card.header.widget.dart
@@ -12,23 +12,48 @@ class CardHeaderWidget extends StatelessWidget {
 
     return ListTile(
       leading: const Icon(Icons.info_outline_rounded),
-      title: AnimatedTextKit(
-        animatedTexts: [
-          TypewriterAnimatedText(
-            localizations.appTitle,
-            textStyle: Theme.of(context).textTheme.bodyText1,
-            speed: const Duration(milliseconds: 200),
-          ),
-        ],
-        totalRepeatCount: 4,
-        pause: const Duration(milliseconds: 1000),
-        displayFullTextOnTap: true,
-        stopPauseOnTap: true,
-      ),
+      title: const HeaderlineWidget(),
       subtitle: Text(
         localizations.appSubTitle,
         style: Theme.of(context).textTheme.bodyText2,
       ),
+    );
+  }
+}
+
+class HeaderlineWidget extends StatelessWidget {
+  const HeaderlineWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+
+    return AnimatedTextKit(
+      animatedTexts: [
+        TypewriterAnimatedText(
+          localizations.appTitle,
+          textStyle: Theme.of(context).textTheme.headline5!.copyWith(
+            decoration: TextDecoration.combine([
+              TextDecoration.overline,
+              TextDecoration.underline,
+            ]),
+            decorationThickness: 1,
+            decorationStyle: TextDecorationStyle.dotted,
+            shadows: [
+              const Shadow(
+                color: Colors.orange,
+                blurRadius: 2,
+                offset: Offset(1, 1),
+              ),
+            ],
+          ),
+          speed: const Duration(milliseconds: 200),
+        ),
+      ],
+      totalRepeatCount: 4,
+      pause: const Duration(milliseconds: 1000),
+      displayFullTextOnTap: true,
+      stopPauseOnTap: true,
     );
   }
 }

--- a/lib/features/about/platform.screen.info.table.widget.dart
+++ b/lib/features/about/platform.screen.info.table.widget.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
@@ -36,15 +37,23 @@ class PlatformScreenInfoTable extends StatelessWidget {
             DataRow(cells: <DataCell>[const DataCell(Text('Type')), DataCell(Text(screenType))]),
             DataRow(cells: <DataCell>[
               const DataCell(Text('Width')),
-              DataCell(Text('${screen.size.width.toInt()} pixels'))
+              DataCell(Text('${window.physicalSize.width.toInt()} px'))
             ]),
             DataRow(cells: <DataCell>[
               const DataCell(Text('Height')),
-              DataCell(Text('${screen.size.height.toInt()} pixels'))
+              DataCell(Text('${window.physicalSize.height.toInt()} px'))
             ]),
             DataRow(cells: <DataCell>[
               const DataCell(Text('Pixel ratio')),
-              DataCell(Text(screen.devicePixelRatio.toString()))
+              DataCell(Text(window.devicePixelRatio.toString()))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Locical width')),
+              DataCell(Text('${screen.size.width.toInt()} px'))
+            ]),
+            DataRow(cells: <DataCell>[
+              const DataCell(Text('Logical height')),
+              DataCell(Text('${screen.size.height.toInt()} px'))
             ]),
             DataRow(cells: <DataCell>[
               const DataCell(Text('Orientation')),

--- a/lib/features/game/game.fab.widget.dart
+++ b/lib/features/game/game.fab.widget.dart
@@ -49,7 +49,7 @@ class _GameFabWidgetState extends State<GameFabWidget> with SingleTickerProvider
     return FloatingActionButton(
       onPressed: onPressed,
       tooltip: 'Shuffle', // TODO translate me i18n
-      backgroundColor: Colors.orange.withOpacity(fadingAnim.value),
+      backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(fadingAnim.value),
       child: RotationTransition(turns: rotationAnim, child: const Icon(Icons.refresh)),
     );
   }

--- a/lib/theme/widgets/menu.logo.widget.dart
+++ b/lib/theme/widgets/menu.logo.widget.dart
@@ -6,10 +6,16 @@ class MenuLogo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final LinearGradient gradient = isDark
+        ? const LinearGradient(
+            colors: [Colors.white, Colors.black], begin: Alignment.topCenter, end: Alignment.bottomCenter)
+        : const LinearGradient(
+            colors: [Colors.orange, Colors.white], begin: Alignment.topCenter, end: Alignment.bottomCenter);
     const assetName = 'assets/images/drawer-header.png';
 
     return DrawerHeader(
       decoration: BoxDecoration(
+          gradient: gradient,
           image: DecorationImage(invertColors: isDark, fit: BoxFit.contain, image: const AssetImage(assetName))),
       child: const Text(''),
     );

--- a/lib/theme/widgets/menu.logo.widget.dart
+++ b/lib/theme/widgets/menu.logo.widget.dart
@@ -8,9 +8,11 @@ class MenuLogo extends StatelessWidget {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final LinearGradient gradient = isDark
         ? const LinearGradient(
-            colors: [Colors.white, Colors.black], begin: Alignment.topCenter, end: Alignment.bottomCenter)
-        : const LinearGradient(
-            colors: [Colors.orange, Colors.white], begin: Alignment.topCenter, end: Alignment.bottomCenter);
+            colors: [Colors.grey, Colors.black], begin: Alignment.topCenter, end: Alignment.bottomCenter)
+        : LinearGradient(
+            colors: [Theme.of(context).colorScheme.primary, Colors.white],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter);
     const assetName = 'assets/images/drawer-header.png';
 
     return DrawerHeader(


### PR DESCRIPTION
### Elements addressed by this pull request

- added device physical screen dimensions to the about screen spec. table
- styled of the animated header of the about screen
- styled the drawer menu bulb header

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android

https://user-images.githubusercontent.com/3459255/174800367-29cd9127-1d6b-4a99-b5b4-6f509382861a.mp4

#### Webapp

https://user-images.githubusercontent.com/3459255/174801220-3fedd12b-45ff-4f09-9f5f-a607a28f050a.mov


