### PR TITLE
style: look & feel on menu and settings

### DIFF
--- a/lib/features/about/about.screen.dart
+++ b/lib/features/about/about.screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import '/theme/theme.utils.dart';
 import '/theme/widgets/app.bar.title.widget.dart';
 import '/theme/widgets/full.screen.bg.image.widget.dart';
-
 import 'card.widget.dart';
 
 class AboutWidget extends StatefulWidget {

--- a/lib/features/settings/brightness.settings.widget.dart
+++ b/lib/features/settings/brightness.settings.widget.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+
+import '/service.locator.dart';
+import 'settings.store.dart';
+
+class BrightnessSettingWidget extends StatelessWidget {
+  const BrightnessSettingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final SettingsStore settings = serviceLocator.get();
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final isDarkTheme = Theme.of(context).brightness == Brightness.dark;
+
+    void themeBrightnessChanged(bool? isDark) {
+      if (isDark != settings.isDarkTheme) {
+        settings.toggleTheme();
+      }
+    }
+
+    return Observer(builder: (context) {
+      return SwitchListTile.adaptive(
+          title: Text(localizations.prefThemeBrightness),
+          subtitle: Text(
+            isDarkTheme ? localizations.prefThemeBrightnessDark : localizations.prefThemeBrightnessLight,
+            style: Theme.of(context).textTheme.bodyText2,
+          ),
+          value: isDarkTheme,
+          activeColor: Theme.of(context).colorScheme.primary,
+          inactiveThumbColor: Colors.grey,
+          secondary: Icon(isDarkTheme ? Icons.nightlight : Icons.sunny),
+          onChanged: themeBrightnessChanged);
+    });
+  }
+}

--- a/lib/features/settings/language.settings.widget.dart
+++ b/lib/features/settings/language.settings.widget.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+
+import '/service.locator.dart';
+import '/utils/language.utils.dart';
+import 'settings.store.dart';
+
+class LanguageSettingWidget extends StatelessWidget {
+  const LanguageSettingWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final SettingsStore settings = serviceLocator.get();
+
+    void changeLanguage(AppLanguage? selectedLanguage) {
+      final AppLanguage? language = codesToLanguageMap[settings.locale.languageCode];
+      if (selectedLanguage != language) {
+        settings.changeLocale(selectedLanguage);
+      }
+    }
+
+    return Observer(builder: (context) {
+      final appLanguage = codesToLanguageMap[settings.locale.languageCode]!;
+
+      return Column(
+        children: <Widget>[
+          ListTile(leading: const Icon(Icons.language), title: Text(localizations.prefLanguage)),
+          LanguageWidget(
+              appLanguage: appLanguage,
+              title: localizations.prefLangFr,
+              language: AppLanguage.fr,
+              changeLanguage: changeLanguage),
+          LanguageWidget(
+              appLanguage: appLanguage,
+              title: localizations.prefLangEn,
+              language: AppLanguage.en,
+              changeLanguage: changeLanguage),
+        ],
+      );
+    });
+  }
+}
+
+class LanguageWidget extends StatelessWidget {
+  const LanguageWidget(
+      {Key? key, required this.title, required this.appLanguage, required this.language, required this.changeLanguage})
+      : super(key: key);
+
+  final String title;
+  final AppLanguage language;
+  final AppLanguage appLanguage;
+  final void Function(AppLanguage? selectedLanguage) changeLanguage;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      dense: true,
+      title: Text(title, style: Theme.of(context).textTheme.bodyText1),
+      onTap: () => changeLanguage(language),
+      leading: Radio<AppLanguage>(
+        value: language,
+        activeColor: Theme.of(context).colorScheme.primary,
+        groupValue: appLanguage,
+        onChanged: changeLanguage,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings.screen.dart
+++ b/lib/features/settings/settings.screen.dart
@@ -1,131 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:guess_the_text/features/settings/brightness.settings.widget.dart';
 
 import '/features/settings/hero.settings.widget.dart';
-import '/service.locator.dart';
 import '/theme/theme.utils.dart';
 import '/theme/widgets/app.bar.title.widget.dart';
 import '/theme/widgets/full.screen.bg.image.widget.dart';
-import '/utils/language.utils.dart';
-import 'settings.store.dart';
+import 'language.settings.widget.dart';
 
-class SettingsWidget extends StatefulWidget {
-  const SettingsWidget({Key? key}) : super(key: key);
-
-  @override
-  State<SettingsWidget> createState() => _SettingsWidgetState();
-}
-
-class _SettingsWidgetState extends State<SettingsWidget> {
+class SettingsWidget extends StatelessWidget {
   static const String backgroundImageDark = 'assets/images/backgrounds/background-pexels-pixabay-461940.jpg';
   static const String backgroundImageLight = 'assets/images/backgrounds/beach-sun.jpg';
 
-  final SettingsStore _settings = serviceLocator.get();
-
-  void themeBrightnessChanged(bool? isDark) {
-    if (isDark != _settings.isDarkTheme) {
-      _settings.toggleTheme();
-    }
-  }
-
-  void changeLanguage(AppLanguage? selectedLanguage) {
-    final AppLanguage? language = codesToLanguageMap[_settings.locale.languageCode];
-    if (selectedLanguage != language) {
-      _settings.changeLocale(selectedLanguage);
-    }
-  }
+  const SettingsWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     final isDarkTheme = Theme.of(context).brightness == Brightness.dark;
 
-    return Observer(builder: (context) {
-      return Scaffold(
-        appBar: AppBar(
-          title: AppBarTitle(title: localizations.preferences),
-        ),
-        body: FullScreenAssetBackground(
-          assetImagePath: isDarkTheme ? backgroundImageDark : backgroundImageLight,
-          child: SingleChildScrollView(
-            child: Padding(
-              padding: EdgeInsets.symmetric(vertical: spacing(1)),
-              child: Column(
-                children: <Widget>[
-                  HeroSettingsWidget(),
-                  ListTile(
-                    leading: const Icon(Icons.language),
-                    title: Text(localizations.prefLanguage),
-                  ),
-                  ListTile(
-                    dense: true,
-                    title: Text(
-                      localizations.prefLangFr,
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                    onTap: () => changeLanguage(AppLanguage.fr),
-                    leading: Radio<AppLanguage>(
-                      value: AppLanguage.fr,
-                      activeColor: Theme.of(context).colorScheme.primary,
-                      groupValue: codesToLanguageMap[_settings.locale.languageCode],
-                      onChanged: changeLanguage,
-                    ),
-                  ),
-                  ListTile(
-                    dense: true,
-                    title: Text(
-                      localizations.prefLangEn,
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                    onTap: () => changeLanguage(AppLanguage.en),
-                    leading: Radio<AppLanguage>(
-                      value: AppLanguage.en,
-                      activeColor: Theme.of(context).colorScheme.primary,
-                      groupValue: codesToLanguageMap[_settings.locale.languageCode],
-                      onChanged: changeLanguage,
-                    ),
-                  ),
-                  const Divider(),
-                  ListTile(
-                    leading: Icon(isDarkTheme ? Icons.nightlight : Icons.sunny),
-                    title: Text(localizations.prefThemeBrightness),
-                  ),
-                  ListTile(
-                    dense: true,
-                    title: Text(
-                      localizations.prefThemeBrightnessLight,
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                    onTap: () => themeBrightnessChanged(false),
-                    leading: Radio<bool>(
-                      value: false,
-                      activeColor: Theme.of(context).colorScheme.primary,
-                      groupValue: isDarkTheme,
-                      onChanged: themeBrightnessChanged,
-                    ),
-                  ),
-                  ListTile(
-                    dense: true,
-                    title: Text(
-                      localizations.prefThemeBrightnessDark,
-                      style: Theme.of(context).textTheme.bodyText1,
-                    ),
-                    onTap: () => themeBrightnessChanged(true),
-                    leading: Radio<bool>(
-                      value: true,
-                      activeColor: Theme.of(context).colorScheme.primary,
-                      groupValue: isDarkTheme,
-                      onChanged: themeBrightnessChanged,
-                    ),
-                  ),
-                  const Divider(),
-                ],
-              ),
+    return Scaffold(
+      appBar: AppBar(
+        title: AppBarTitle(title: localizations.preferences),
+      ),
+      body: FullScreenAssetBackground(
+        assetImagePath: isDarkTheme ? backgroundImageDark : backgroundImageLight,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: spacing(1)),
+            child: Column(
+              children: <Widget>[
+                HeroSettingsWidget(),
+                const LanguageSettingWidget(),
+                const Divider(),
+                const BrightnessSettingWidget(),
+                const Divider(),
+              ],
             ),
           ),
         ),
-      );
-    });
+      ),
+    );
   }
 }

--- a/lib/route.generator.dart
+++ b/lib/route.generator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '/features/about/about.screen.dart';
 import '/features/categories/categories.screen.dart';
 import '/features/game/challenge/on.the.fly.chalenge.qr.screen.dart';

--- a/lib/service.locator.dart
+++ b/lib/service.locator.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+
 import '/documents.repository.dart';
 import '/features/game/api.texts.service.dart';
 import '/features/game/game.played.items.storage.service.dart';
@@ -10,7 +11,6 @@ import '/services/storage/shared.preferences.services.dart';
 import '/store/fixed.delay.spinner.store.dart';
 import '/utils/animation.utils.dart';
 import '/utils/randomizer.utils.dart';
-
 import 'features/settings/settings.store.dart';
 
 final serviceLocator = GetIt.instance;

--- a/lib/theme/widgets/app.menu.item.widget.dart
+++ b/lib/theme/widgets/app.menu.item.widget.dart
@@ -19,6 +19,7 @@ class MenuItemWidget extends StatelessWidget {
             tag: 'app-menu-item-$iconName',
             child: Icon(iconsMap[iconName]),
           ),
+          trailing: const Icon(Icons.arrow_right),
           title: Text(titleLabel),
           onTap: onTap,
         ),


### PR DESCRIPTION
### Elements addressed by this pull request

- refactored the settings screen: applied _divide to conquer rule_ to promote smaller maintainable widgets
- added trailing `arrow_right` to app menu items
- converted theme brightness preference from radio buttons to single switch

### Checklist

- [ ] Unit tests completed
- [x] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### iOS

https://user-images.githubusercontent.com/3459255/177018433-ffd5b526-bde3-4ce5-acea-ba737485ef88.mov

#### Android

https://user-images.githubusercontent.com/3459255/177018505-f52a873c-1a86-45ca-8cdc-73ed0d6baee9.mp4


