### PR TITLE
feat: use Freezed lib for models (toJson, toString, copyWith…)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,8 @@
 ### Checklist
 
 - [ ] Unit tests completed
-- [ ] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
+- [ ] Tested NON-UI changes on at least one device
+- [ ] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
 - [ ] Added corresponding screen capture or video
 - [ ] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - '**/*.g.dart'
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/lib/features/about/api.about.model.dart
+++ b/lib/features/about/api.about.model.dart
@@ -1,16 +1,14 @@
-class ApiAbout {
-  final String name;
-  final String version;
-  final String description;
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  ApiAbout({this.name = 'hangman', this.version = 'N/A', this.description = 'N/A'});
+part 'api.about.model.freezed.dart';
+part 'api.about.model.g.dart';
 
-  factory ApiAbout.fromJson(Map<String, dynamic> json) {
-    return ApiAbout(name: json['name'], description: json['description'], version: json['version']);
-  }
+@Freezed()
+class ApiAbout with _$ApiAbout {
+  const factory ApiAbout(
+      {@Default('hangman') String name,
+      @Default('N/A') String version,
+      @Default('N/A') String description}) = _ApiAbout;
 
-  @override
-  String toString() {
-    return '{ $name, $version }';
-  }
+  factory ApiAbout.fromJson(Map<String, dynamic> json) => _$ApiAboutFromJson(json);
 }

--- a/lib/features/about/api.about.model.freezed.dart
+++ b/lib/features/about/api.about.model.freezed.dart
@@ -1,0 +1,185 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'api.about.model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ApiAbout _$ApiAboutFromJson(Map<String, dynamic> json) {
+  return _ApiAbout.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ApiAbout {
+  String get name => throw _privateConstructorUsedError;
+  String get version => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ApiAboutCopyWith<ApiAbout> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiAboutCopyWith<$Res> {
+  factory $ApiAboutCopyWith(ApiAbout value, $Res Function(ApiAbout) then) =
+      _$ApiAboutCopyWithImpl<$Res>;
+  $Res call({String name, String version, String description});
+}
+
+/// @nodoc
+class _$ApiAboutCopyWithImpl<$Res> implements $ApiAboutCopyWith<$Res> {
+  _$ApiAboutCopyWithImpl(this._value, this._then);
+
+  final ApiAbout _value;
+  // ignore: unused_field
+  final $Res Function(ApiAbout) _then;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? version = freezed,
+    Object? description = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: version == freezed
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ApiAboutCopyWith<$Res> implements $ApiAboutCopyWith<$Res> {
+  factory _$$_ApiAboutCopyWith(
+          _$_ApiAbout value, $Res Function(_$_ApiAbout) then) =
+      __$$_ApiAboutCopyWithImpl<$Res>;
+  @override
+  $Res call({String name, String version, String description});
+}
+
+/// @nodoc
+class __$$_ApiAboutCopyWithImpl<$Res> extends _$ApiAboutCopyWithImpl<$Res>
+    implements _$$_ApiAboutCopyWith<$Res> {
+  __$$_ApiAboutCopyWithImpl(
+      _$_ApiAbout _value, $Res Function(_$_ApiAbout) _then)
+      : super(_value, (v) => _then(v as _$_ApiAbout));
+
+  @override
+  _$_ApiAbout get _value => super._value as _$_ApiAbout;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? version = freezed,
+    Object? description = freezed,
+  }) {
+    return _then(_$_ApiAbout(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: version == freezed
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: description == freezed
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ApiAbout implements _ApiAbout {
+  const _$_ApiAbout(
+      {this.name = 'hangman', this.version = 'N/A', this.description = 'N/A'});
+
+  factory _$_ApiAbout.fromJson(Map<String, dynamic> json) =>
+      _$$_ApiAboutFromJson(json);
+
+  @override
+  @JsonKey()
+  final String name;
+  @override
+  @JsonKey()
+  final String version;
+  @override
+  @JsonKey()
+  final String description;
+
+  @override
+  String toString() {
+    return 'ApiAbout(name: $name, version: $version, description: $description)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ApiAbout &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality().equals(other.version, version) &&
+            const DeepCollectionEquality()
+                .equals(other.description, description));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(version),
+      const DeepCollectionEquality().hash(description));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ApiAboutCopyWith<_$_ApiAbout> get copyWith =>
+      __$$_ApiAboutCopyWithImpl<_$_ApiAbout>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ApiAboutToJson(this);
+  }
+}
+
+abstract class _ApiAbout implements ApiAbout {
+  const factory _ApiAbout(
+      {final String name,
+      final String version,
+      final String description}) = _$_ApiAbout;
+
+  factory _ApiAbout.fromJson(Map<String, dynamic> json) = _$_ApiAbout.fromJson;
+
+  @override
+  String get name => throw _privateConstructorUsedError;
+  @override
+  String get version => throw _privateConstructorUsedError;
+  @override
+  String get description => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ApiAboutCopyWith<_$_ApiAbout> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/about/api.about.model.g.dart
+++ b/lib/features/about/api.about.model.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api.about.model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ApiAbout _$$_ApiAboutFromJson(Map<String, dynamic> json) => _$_ApiAbout(
+      name: json['name'] as String? ?? 'hangman',
+      version: json['version'] as String? ?? 'N/A',
+      description: json['description'] as String? ?? 'N/A',
+    );
+
+Map<String, dynamic> _$$_ApiAboutToJson(_$_ApiAbout instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'version': instance.version,
+      'description': instance.description,
+    };

--- a/lib/features/about/app.version.table.widget.dart
+++ b/lib/features/about/app.version.table.widget.dart
@@ -9,9 +9,7 @@ import '/service.locator.dart';
 import '/theme/widgets/text.link.widget.dart';
 
 class AppVersionTable extends StatefulWidget {
-  const AppVersionTable({
-    Key? key,
-  }) : super(key: key);
+  const AppVersionTable({Key? key}) : super(key: key);
 
   @override
   State<AppVersionTable> createState() => _AppVersionTableState();
@@ -22,7 +20,7 @@ class _AppVersionTableState extends State<AppVersionTable> {
 
   String _appVersion = '';
   String _appBuildNumber = '';
-  ApiAbout _apiAbout = ApiAbout();
+  ApiAbout _apiAbout = const ApiAbout();
 
   @override
   void initState() {

--- a/lib/features/about/card.widget.dart
+++ b/lib/features/about/card.widget.dart
@@ -4,8 +4,8 @@ import 'package:responsive_framework/responsive_framework.dart';
 import '/features/about/card.app.description.dart';
 import '/features/about/card.header.widget.dart';
 import '/features/about/platform.screen.info.table.widget.dart';
-import '/theme/widgets/made.with.love.widget.dart';
 import '/theme/theme.utils.dart';
+import '/theme/widgets/made.with.love.widget.dart';
 import 'app.version.table.widget.dart';
 import 'platform.info.table.widget.dart';
 

--- a/lib/features/categories/api.category.model.dart
+++ b/lib/features/categories/api.category.model.dart
@@ -1,25 +1,17 @@
-class ApiCategory {
-  final int id;
-  final String uuid;
-  final String langCode;
-  final String name;
-  final String iconName;
-  final bool isCustom;
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  ApiCategory(
-      {this.id = 0, this.uuid = '', this.langCode = '', this.name = '', this.iconName = '', this.isCustom = false});
+part 'api.category.model.freezed.dart';
+part 'api.category.model.g.dart';
 
-  bool get isEmpty => id == 0;
+@Freezed()
+class ApiCategory with _$ApiCategory {
+  const factory ApiCategory(
+      {@Default(0) id,
+      @Default('') uuid,
+      @Default('') langCode,
+      @Default('') name,
+      @Default('') iconName,
+      @Default(false) isCustom}) = _ApiCategory;
 
-  factory ApiCategory.fromJson(Map<String, dynamic> json) => ApiCategory(
-      id: json['id'] as int,
-      uuid: json['uuid'] as String,
-      langCode: json['langcode'] as String,
-      name: json['name'] as String,
-      iconName: json['iconname'] as String);
-
-  @override
-  String toString() {
-    return '{ $id, $langCode, $name, $iconName }';
-  }
+  factory ApiCategory.fromJson(Map<String, dynamic> json) => _$ApiCategoryFromJson(json);
 }

--- a/lib/features/categories/api.category.model.freezed.dart
+++ b/lib/features/categories/api.category.model.freezed.dart
@@ -1,0 +1,243 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'api.category.model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ApiCategory _$ApiCategoryFromJson(Map<String, dynamic> json) {
+  return _ApiCategory.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ApiCategory {
+  dynamic get id => throw _privateConstructorUsedError;
+  dynamic get uuid => throw _privateConstructorUsedError;
+  dynamic get langCode => throw _privateConstructorUsedError;
+  dynamic get name => throw _privateConstructorUsedError;
+  dynamic get iconName => throw _privateConstructorUsedError;
+  dynamic get isCustom => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ApiCategoryCopyWith<ApiCategory> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiCategoryCopyWith<$Res> {
+  factory $ApiCategoryCopyWith(
+          ApiCategory value, $Res Function(ApiCategory) then) =
+      _$ApiCategoryCopyWithImpl<$Res>;
+  $Res call(
+      {dynamic id,
+      dynamic uuid,
+      dynamic langCode,
+      dynamic name,
+      dynamic iconName,
+      dynamic isCustom});
+}
+
+/// @nodoc
+class _$ApiCategoryCopyWithImpl<$Res> implements $ApiCategoryCopyWith<$Res> {
+  _$ApiCategoryCopyWithImpl(this._value, this._then);
+
+  final ApiCategory _value;
+  // ignore: unused_field
+  final $Res Function(ApiCategory) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uuid = freezed,
+    Object? langCode = freezed,
+    Object? name = freezed,
+    Object? iconName = freezed,
+    Object? isCustom = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      uuid: uuid == freezed
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      langCode: langCode == freezed
+          ? _value.langCode
+          : langCode // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      iconName: iconName == freezed
+          ? _value.iconName
+          : iconName // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      isCustom: isCustom == freezed
+          ? _value.isCustom
+          : isCustom // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ApiCategoryCopyWith<$Res>
+    implements $ApiCategoryCopyWith<$Res> {
+  factory _$$_ApiCategoryCopyWith(
+          _$_ApiCategory value, $Res Function(_$_ApiCategory) then) =
+      __$$_ApiCategoryCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {dynamic id,
+      dynamic uuid,
+      dynamic langCode,
+      dynamic name,
+      dynamic iconName,
+      dynamic isCustom});
+}
+
+/// @nodoc
+class __$$_ApiCategoryCopyWithImpl<$Res> extends _$ApiCategoryCopyWithImpl<$Res>
+    implements _$$_ApiCategoryCopyWith<$Res> {
+  __$$_ApiCategoryCopyWithImpl(
+      _$_ApiCategory _value, $Res Function(_$_ApiCategory) _then)
+      : super(_value, (v) => _then(v as _$_ApiCategory));
+
+  @override
+  _$_ApiCategory get _value => super._value as _$_ApiCategory;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uuid = freezed,
+    Object? langCode = freezed,
+    Object? name = freezed,
+    Object? iconName = freezed,
+    Object? isCustom = freezed,
+  }) {
+    return _then(_$_ApiCategory(
+      id: id == freezed ? _value.id : id,
+      uuid: uuid == freezed ? _value.uuid : uuid,
+      langCode: langCode == freezed ? _value.langCode : langCode,
+      name: name == freezed ? _value.name : name,
+      iconName: iconName == freezed ? _value.iconName : iconName,
+      isCustom: isCustom == freezed ? _value.isCustom : isCustom,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ApiCategory implements _ApiCategory {
+  const _$_ApiCategory(
+      {this.id = 0,
+      this.uuid = '',
+      this.langCode = '',
+      this.name = '',
+      this.iconName = '',
+      this.isCustom = false});
+
+  factory _$_ApiCategory.fromJson(Map<String, dynamic> json) =>
+      _$$_ApiCategoryFromJson(json);
+
+  @override
+  @JsonKey()
+  final dynamic id;
+  @override
+  @JsonKey()
+  final dynamic uuid;
+  @override
+  @JsonKey()
+  final dynamic langCode;
+  @override
+  @JsonKey()
+  final dynamic name;
+  @override
+  @JsonKey()
+  final dynamic iconName;
+  @override
+  @JsonKey()
+  final dynamic isCustom;
+
+  @override
+  String toString() {
+    return 'ApiCategory(id: $id, uuid: $uuid, langCode: $langCode, name: $name, iconName: $iconName, isCustom: $isCustom)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ApiCategory &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.uuid, uuid) &&
+            const DeepCollectionEquality().equals(other.langCode, langCode) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality().equals(other.iconName, iconName) &&
+            const DeepCollectionEquality().equals(other.isCustom, isCustom));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(uuid),
+      const DeepCollectionEquality().hash(langCode),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(iconName),
+      const DeepCollectionEquality().hash(isCustom));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ApiCategoryCopyWith<_$_ApiCategory> get copyWith =>
+      __$$_ApiCategoryCopyWithImpl<_$_ApiCategory>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ApiCategoryToJson(this);
+  }
+}
+
+abstract class _ApiCategory implements ApiCategory {
+  const factory _ApiCategory(
+      {final dynamic id,
+      final dynamic uuid,
+      final dynamic langCode,
+      final dynamic name,
+      final dynamic iconName,
+      final dynamic isCustom}) = _$_ApiCategory;
+
+  factory _ApiCategory.fromJson(Map<String, dynamic> json) =
+      _$_ApiCategory.fromJson;
+
+  @override
+  dynamic get id => throw _privateConstructorUsedError;
+  @override
+  dynamic get uuid => throw _privateConstructorUsedError;
+  @override
+  dynamic get langCode => throw _privateConstructorUsedError;
+  @override
+  dynamic get name => throw _privateConstructorUsedError;
+  @override
+  dynamic get iconName => throw _privateConstructorUsedError;
+  @override
+  dynamic get isCustom => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ApiCategoryCopyWith<_$_ApiCategory> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/categories/api.category.model.g.dart
+++ b/lib/features/categories/api.category.model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api.category.model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ApiCategory _$$_ApiCategoryFromJson(Map<String, dynamic> json) =>
+    _$_ApiCategory(
+      id: json['id'] ?? 0,
+      uuid: json['uuid'] ?? '',
+      langCode: json['langCode'] ?? '',
+      name: json['name'] ?? '',
+      iconName: json['iconName'] ?? '',
+      isCustom: json['isCustom'] ?? false,
+    );
+
+Map<String, dynamic> _$$_ApiCategoryToJson(_$_ApiCategory instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'uuid': instance.uuid,
+      'langCode': instance.langCode,
+      'name': instance.name,
+      'iconName': instance.iconName,
+      'isCustom': instance.isCustom,
+    };

--- a/lib/features/game/api.text.model.dart
+++ b/lib/features/game/api.text.model.dart
@@ -1,19 +1,11 @@
-class ApiText {
-  final int id;
-  final String uuid;
-  final String original;
-  final String normalized;
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  ApiText({this.id = 0, this.uuid = '', this.original = '', this.normalized = ''});
+part 'api.text.model.freezed.dart';
+part 'api.text.model.g.dart';
 
-  factory ApiText.fromJson(Map<String, dynamic> json) => ApiText(
-      id: json['id'] as int,
-      uuid: json['uuid'] as String,
-      original: json['original'] as String,
-      normalized: json['normalized'] as String);
+@Freezed()
+class ApiText with _$ApiText {
+  const factory ApiText({@Default(0) id, @Default('') uuid, @Default('') original, @Default('') normalized}) = _ApiText;
 
-  @override
-  String toString() {
-    return '{ $id, $original }';
-  }
+  factory ApiText.fromJson(Map<String, dynamic> json) => _$ApiTextFromJson(json);
 }

--- a/lib/features/game/api.text.model.freezed.dart
+++ b/lib/features/game/api.text.model.freezed.dart
@@ -1,0 +1,190 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'api.text.model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ApiText _$ApiTextFromJson(Map<String, dynamic> json) {
+  return _ApiText.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ApiText {
+  dynamic get id => throw _privateConstructorUsedError;
+  dynamic get uuid => throw _privateConstructorUsedError;
+  dynamic get original => throw _privateConstructorUsedError;
+  dynamic get normalized => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ApiTextCopyWith<ApiText> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiTextCopyWith<$Res> {
+  factory $ApiTextCopyWith(ApiText value, $Res Function(ApiText) then) =
+      _$ApiTextCopyWithImpl<$Res>;
+  $Res call({dynamic id, dynamic uuid, dynamic original, dynamic normalized});
+}
+
+/// @nodoc
+class _$ApiTextCopyWithImpl<$Res> implements $ApiTextCopyWith<$Res> {
+  _$ApiTextCopyWithImpl(this._value, this._then);
+
+  final ApiText _value;
+  // ignore: unused_field
+  final $Res Function(ApiText) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uuid = freezed,
+    Object? original = freezed,
+    Object? normalized = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      uuid: uuid == freezed
+          ? _value.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      original: original == freezed
+          ? _value.original
+          : original // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+      normalized: normalized == freezed
+          ? _value.normalized
+          : normalized // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ApiTextCopyWith<$Res> implements $ApiTextCopyWith<$Res> {
+  factory _$$_ApiTextCopyWith(
+          _$_ApiText value, $Res Function(_$_ApiText) then) =
+      __$$_ApiTextCopyWithImpl<$Res>;
+  @override
+  $Res call({dynamic id, dynamic uuid, dynamic original, dynamic normalized});
+}
+
+/// @nodoc
+class __$$_ApiTextCopyWithImpl<$Res> extends _$ApiTextCopyWithImpl<$Res>
+    implements _$$_ApiTextCopyWith<$Res> {
+  __$$_ApiTextCopyWithImpl(_$_ApiText _value, $Res Function(_$_ApiText) _then)
+      : super(_value, (v) => _then(v as _$_ApiText));
+
+  @override
+  _$_ApiText get _value => super._value as _$_ApiText;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? uuid = freezed,
+    Object? original = freezed,
+    Object? normalized = freezed,
+  }) {
+    return _then(_$_ApiText(
+      id: id == freezed ? _value.id : id,
+      uuid: uuid == freezed ? _value.uuid : uuid,
+      original: original == freezed ? _value.original : original,
+      normalized: normalized == freezed ? _value.normalized : normalized,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ApiText implements _ApiText {
+  const _$_ApiText(
+      {this.id = 0, this.uuid = '', this.original = '', this.normalized = ''});
+
+  factory _$_ApiText.fromJson(Map<String, dynamic> json) =>
+      _$$_ApiTextFromJson(json);
+
+  @override
+  @JsonKey()
+  final dynamic id;
+  @override
+  @JsonKey()
+  final dynamic uuid;
+  @override
+  @JsonKey()
+  final dynamic original;
+  @override
+  @JsonKey()
+  final dynamic normalized;
+
+  @override
+  String toString() {
+    return 'ApiText(id: $id, uuid: $uuid, original: $original, normalized: $normalized)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ApiText &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.uuid, uuid) &&
+            const DeepCollectionEquality().equals(other.original, original) &&
+            const DeepCollectionEquality()
+                .equals(other.normalized, normalized));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(uuid),
+      const DeepCollectionEquality().hash(original),
+      const DeepCollectionEquality().hash(normalized));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ApiTextCopyWith<_$_ApiText> get copyWith =>
+      __$$_ApiTextCopyWithImpl<_$_ApiText>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ApiTextToJson(this);
+  }
+}
+
+abstract class _ApiText implements ApiText {
+  const factory _ApiText(
+      {final dynamic id,
+      final dynamic uuid,
+      final dynamic original,
+      final dynamic normalized}) = _$_ApiText;
+
+  factory _ApiText.fromJson(Map<String, dynamic> json) = _$_ApiText.fromJson;
+
+  @override
+  dynamic get id => throw _privateConstructorUsedError;
+  @override
+  dynamic get uuid => throw _privateConstructorUsedError;
+  @override
+  dynamic get original => throw _privateConstructorUsedError;
+  @override
+  dynamic get normalized => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ApiTextCopyWith<_$_ApiText> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/game/api.text.model.g.dart
+++ b/lib/features/game/api.text.model.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api.text.model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ApiText _$$_ApiTextFromJson(Map<String, dynamic> json) => _$_ApiText(
+      id: json['id'] ?? 0,
+      uuid: json['uuid'] ?? '',
+      original: json['original'] ?? '',
+      normalized: json['normalized'] ?? '',
+    );
+
+Map<String, dynamic> _$$_ApiTextToJson(_$_ApiText instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'uuid': instance.uuid,
+      'original': instance.original,
+      'normalized': instance.normalized,
+    };

--- a/lib/features/game/api.texts.service.dart
+++ b/lib/features/game/api.texts.service.dart
@@ -36,7 +36,7 @@ class TextsService {
       return ApiAbout.fromJson(body);
     } catch (e) {
       logger.error('About request failed', e);
-      return ApiAbout();
+      return const ApiAbout();
     }
   }
 

--- a/lib/features/game/game.store.dart
+++ b/lib/features/game/game.store.dart
@@ -24,7 +24,7 @@ abstract class _GameStoreBase with Store {
   final GamePlayedItemsStorageService gamePlayedItemsStorageService = serviceLocator.get();
 
   @observable
-  ApiCategory currentCategory = ApiCategory();
+  ApiCategory currentCategory = const ApiCategory();
 
   @observable
   TextToGuess textToGuess = TextToGuess();

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -7,11 +7,8 @@ class AppMenu extends StatelessWidget {
   final Function() onCreateChallengePress;
   final Function() onAcceptChallengePress;
 
-  const AppMenu({
-    Key? key,
-    required this.onCreateChallengePress,
-    required this.onAcceptChallengePress,
-  }) : super(key: key);
+  const AppMenu({Key? key, required this.onCreateChallengePress, required this.onAcceptChallengePress})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -443,7 +443,7 @@ packages:
     source: hosted
     version: "0.6.4"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -334,6 +334,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3+1"
+  freezed_annotation:
+    dependency: "direct main"
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   frontend_server_client:
     dependency: transitive
     description:
@@ -435,6 +449,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.5.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.2.0"
   lint:
     dependency: transitive
     description:
@@ -790,6 +811,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.2"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,34 +27,34 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  animated_text_kit: ^4.2.1
+  barcode: ^2.2.0
+  cupertino_icons: ^1.0.2
+  device_info_plus: ^3.2.2
   flutter:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  cupertino_icons: ^1.0.2
-  intl: ^0.17.0
-  http: ^0.13.4
-  flutter_spinkit: "^5.1.0"
-  flutter_mobx: ^2.0.4
-  mobx: ^2.0.7+2
-  lottie: ^1.2.2
-  flutter_native_splash: ^2.1.0
-  device_info_plus: ^3.2.2
-  package_info_plus: ^1.4.0
-  url_launcher: ^6.0.20
-  shared_preferences: ^2.0.13
-  flutter_svg: ^1.0.3
   flutter_barcode_scanner: ^2.0.0
-  barcode: ^2.2.0
-  animated_text_kit: ^4.2.1
+  flutter_mobx: ^2.0.4
+  flutter_native_splash: ^2.1.0
+  flutter_spinkit: "^5.1.0"
+  flutter_svg: ^1.0.3
+  freezed_annotation: ^2.0.3
   get_it: ^7.2.0
-  sembast: ^3.2.0
-  path_provider: ^2.0.10
+  http: ^0.13.4
+  intl: ^0.17.0
+  lottie: ^1.2.2
+  mobx: ^2.0.7+2
+  package_info_plus: ^1.4.0
   path: ^1.8.1
-  sembast_web: ^2.0.1+1
-  universal_io: ^2.0.4
+  path_provider: ^2.0.10
   responsive_framework: ^0.2.0
-
+  sembast: ^3.2.0
+  sembast_web: ^2.0.1+1
+  shared_preferences: ^2.0.13
+  universal_io: ^2.0.4
+  url_launcher: ^6.0.20
 dev_dependencies:
   integration_test:
     sdk: flutter
@@ -65,11 +65,13 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
+  build_runner: ^2.1.8
   flutter_lints: ^2.0.1
   flutter_launcher_icons: "^0.9.2"
-  build_runner: ^2.1.8
-  mockito: ^5.1.0
+  freezed: ^2.0.3+1
+  json_serializable: ^6.2.0
   mobx_codegen: ^2.0.5+2
+  mockito: ^5.1.0
 
 flutter_icons:
   android: "ic_launcher"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   get_it: ^7.2.0
   http: ^0.13.4
   intl: ^0.17.0
+  json_annotation: ^4.5.0
   lottie: ^1.2.2
   mobx: ^2.0.7+2
   package_info_plus: ^1.4.0

--- a/test/features/categories/api.category.model_test.dart
+++ b/test/features/categories/api.category.model_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guess_the_text/features/categories/api.category.model.dart';
+
+import '../../mocks/categories.mocks.dart';
+
+void main() {
+  group('ApiCategory', () {
+    test('should read/write JSON', () {
+      // given
+      const category = mockUSStatesCategory;
+
+      // when
+      final json = category.toJson();
+
+      // then
+      expect(json, isNotEmpty);
+      expect(ApiCategory.fromJson(json), category, reason: 'model instances should be equal');
+    });
+
+    test('should implement toString', () {
+      // when
+      final string = mockUSStatesCategory.toString();
+
+      // then
+      expect(string, isNotEmpty);
+      expect(string, contains(mockUSStatesCategory.langCode));
+      expect(string, contains(mockUSStatesCategory.iconName));
+      expect(string, contains(mockUSStatesCategory.uuid));
+    });
+
+    test('should implement hashCode', () {
+      // when
+      final hashCode = mockUSStatesCategory.hashCode;
+      final hashCode2 = mockPlanetsCategory.hashCode;
+
+      // then
+      expect(hashCode, greaterThan(0));
+      expect(hashCode2, greaterThan(0));
+      expect(hashCode, isNot(hashCode2));
+    });
+
+    test('should implement copyWith', () {
+      // when
+      final newCaterogy = mockUSStatesCategory.copyWith(uuid: 'Chuck Norris UUID is a fist of fury');
+
+      // then
+      expect(newCaterogy.hashCode, isNot(mockUSStatesCategory.hashCode));
+
+      // when
+      final twinCategory = mockUSStatesCategory.copyWith();
+
+      // then
+      expect(twinCategory.hashCode, mockUSStatesCategory.hashCode);
+    });
+  });
+}

--- a/test/features/categories/api.category.model_test.dart
+++ b/test/features/categories/api.category.model_test.dart
@@ -40,17 +40,23 @@ void main() {
     });
 
     test('should implement copyWith', () {
+      // given
+      const newUUID = 'Chuck Norris UUID is a fist of fury';
+
       // when
-      final newCaterogy = mockUSStatesCategory.copyWith(uuid: 'Chuck Norris UUID is a fist of fury');
+      final newCaterogy = mockUSStatesCategory.copyWith(uuid: newUUID);
 
       // then
       expect(newCaterogy.hashCode, isNot(mockUSStatesCategory.hashCode));
+      expect(newCaterogy.uuid, isNot(mockUSStatesCategory.uuid));
+      expect(newCaterogy.uuid, newUUID);
 
       // when
       final twinCategory = mockUSStatesCategory.copyWith();
 
       // then
       expect(twinCategory.hashCode, mockUSStatesCategory.hashCode);
+      expect(twinCategory, mockUSStatesCategory);
     });
   });
 }

--- a/test/mocks/api.text.mocks.dart
+++ b/test/mocks/api.text.mocks.dart
@@ -1,13 +1,13 @@
 import 'package:guess_the_text/features/game/api.text.model.dart';
 
-final mockTextToGuessFish = ApiText(
+const mockTextToGuessFish = ApiText(
   id: 1,
   uuid: 'fish-uuid',
   original: 'fish',
   normalized: 'fish',
 );
 
-final mockTextToGuessWolf = ApiText(
+const mockTextToGuessWolf = ApiText(
   id: 1,
   uuid: 'wolf-uuid',
   original: 'wolf',

--- a/test/mocks/categories.mocks.dart
+++ b/test/mocks/categories.mocks.dart
@@ -1,41 +1,41 @@
 import 'package:guess_the_text/features/categories/api.category.model.dart';
 
-final mockAnimalsCategory = ApiCategory(
+const mockAnimalsCategory = ApiCategory(
   id: 1,
   uuid: 'animals-uuid',
   langCode: 'en',
   name: 'animals',
 );
 
-final mockTransportsCategory = ApiCategory(
+const mockTransportsCategory = ApiCategory(
   id: 2,
   uuid: 'transports-uuid',
   langCode: 'en',
   name: 'transports',
 );
 
-final mockColorsCategory = ApiCategory(
+const mockColorsCategory = ApiCategory(
   id: 3,
   uuid: 'colors-uuid',
   langCode: 'en',
   name: 'colors',
 );
 
-final mockUSStatesCategory = ApiCategory(
+const mockUSStatesCategory = ApiCategory(
   id: 4,
   uuid: 'usstates-uuid',
   langCode: 'en',
   name: 'U.S state names',
 );
 
-final mockPlanetsCategory = ApiCategory(
+const mockPlanetsCategory = ApiCategory(
   id: 5,
   uuid: 'planets-uuid',
   langCode: 'en',
   name: 'planets',
 );
 
-final mockCountriesCategory = ApiCategory(
+const mockCountriesCategory = ApiCategory(
   id: 6,
   uuid: 'countries-uuid',
   langCode: 'en',


### PR DESCRIPTION
## [Issue 35](https://github.com/amwebexpert/guess_the_text/issues/35)

### Elements addressed by this pull request

- Automate generation of JSON serialization methods
- affected classes: `ApiAbout`, `ApiText`, `ApiCategory`

Usage of the popular [Freezed](https://pub.dev/packages/freezed) library to generate boilerplate methods like:
- toString
- toJson
- fromJson
- copyWith
- equals
- hashcode

Nice quick [tutorial here](https://www.youtube.com/watch?v=RaThk0fiphA)

### Checklist

- [x] Unit tests completed
- [x] Tested NON-UI changes on at least one device
- [ ] Tested on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

![image](https://user-images.githubusercontent.com/3459255/177059806-1f3dee2b-408f-4b64-a36b-aca5b1ebfee0.png)

https://user-images.githubusercontent.com/3459255/177059034-2dd6bc53-fe85-4d17-ba03-ec6aa739325c.mp4


