### PR TITLE
fix: landscape game layout extra right padding

### DIFF
--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -10,11 +10,6 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final leftFlexWeight = ResponsiveValue(
-      context,
-      defaultValue: 1,
-      valueWhen: const [Condition.largerThan(name: TABLET, value: 1)],
-    ).value!;
     final rightFlexWeight = ResponsiveValue(
       context,
       defaultValue: 1,
@@ -24,7 +19,7 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        Flexible(flex: leftFlexWeight, child: const TextAndKeyboardWidget()),
+        const Flexible(flex: 1, child: TextAndKeyboardWidget()),
         Flexible(flex: rightFlexWeight, child: const GameImageWidget()),
       ],
     );

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -11,6 +11,7 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const leftFlexWeight = 1;
     final rightFlexWeight = ResponsiveValue(
       context,
       defaultValue: 1,
@@ -22,7 +23,7 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          const Flexible(flex: 1, fit: FlexFit.tight, child: TextAndKeyboardWidget()),
+          const Flexible(flex: leftFlexWeight, fit: FlexFit.tight, child: TextAndKeyboardWidget()),
           Flexible(flex: rightFlexWeight, fit: FlexFit.tight, child: const GameImageWidget()),
         ],
       ),

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -22,6 +22,7 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
     ).value!;
 
     return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Flexible(flex: leftFlexWeight, child: const TextAndKeyboardWidget()),
         Flexible(flex: rightFlexWeight, child: const GameImageWidget()),

--- a/lib/features/game/game.layout.landscape.widget.dart
+++ b/lib/features/game/game.layout.landscape.widget.dart
@@ -4,6 +4,7 @@ import 'package:responsive_framework/responsive_framework.dart';
 import '/features/game/game.image.widget.dart';
 import '/features/game/game.interaction.panel.widget.dart';
 import '/features/game/text.and.category.widget.dart';
+import '/theme/theme.utils.dart';
 
 class GameLayoutLandscapeWidget extends StatelessWidget {
   const GameLayoutLandscapeWidget({Key? key}) : super(key: key);
@@ -16,12 +17,15 @@ class GameLayoutLandscapeWidget extends StatelessWidget {
       valueWhen: const [Condition.largerThan(name: TABLET, value: 2)],
     ).value!;
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Flexible(flex: 1, child: TextAndKeyboardWidget()),
-        Flexible(flex: rightFlexWeight, child: const GameImageWidget()),
-      ],
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: spacing(1)),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          const Flexible(flex: 1, fit: FlexFit.tight, child: TextAndKeyboardWidget()),
+          Flexible(flex: rightFlexWeight, fit: FlexFit.tight, child: const GameImageWidget()),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
### Elements addressed by this pull request

- removed extra right padding by using both `mainAxisAlignment` and `FlexFit.tight`
- added horizontal padding

### Checklist

- [ ] Unit tests completed
- [ ] Tested NON-UI changes on at least one device
- [x] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Webapp
BEFORE | AFTER
-------- | -------
![image](https://user-images.githubusercontent.com/3459255/178143020-76992fdb-5a9d-456b-91d9-777b0cd3256c.png) | ![image](https://user-images.githubusercontent.com/3459255/178143001-cf0324f0-1890-4d88-9af8-1887fe944c19.png)


#### Android
BEFORE | AFTER
-------- | -------
![image](https://user-images.githubusercontent.com/3459255/178143116-d16c911a-7f86-43a5-afa8-52dc712c89c6.png) | ![image](https://user-images.githubusercontent.com/3459255/178143129-780ea58a-269d-4907-8389-a084229831a5.png)
