### PR TITLE
fix: map json serialization names

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ From there, just run the `guess_the_text` executable to run the build!
 - [Existing Dart language extensions](https://pub.dev/packages/dartx)
 - [Platform conditional widget rendering - Material / Cupertino management](https://pub.dev/packages/flutter_platform_widgets)
 - [Platform conditional widget rendering - Medium article](https://medium.com/flutter/do-flutter-apps-dream-of-platform-aware-widgets-7d7ed7b4624d)
+- [How to Parse JSON in Dart/Flutter with Code Generation using Freezed](https://codewithandrea.com/articles/parse-json-dart-codegen-freezed/)
 
 
 ## Troubleshothing

--- a/README.md
+++ b/README.md
@@ -194,8 +194,6 @@ From there, just run the `guess_the_text` executable to run the build!
 - [WikiMedia dev portal](https://developer.wikimedia.org/use-content/content/)
 - [Huge free french words list](https://www.freelang.com/dictionnaire/dic-francais.php#google_vignette)
 - [Another Flutter Hangman project](https://github.com/tavasolireza/Hangman-Game-Flutter)
-- [English food list](https://www.wordnik.com/lists/food--21)
-- [English words list](https://github.com/Xethron/Hangman/blob/master/words.txt)
 - [Happy robot 1](https://freesvg.org/happy-robot)
 - [Happy robot 2](https://freesvg.org/happy-robot-remix)
 - [Happy robot 3](https://freesvg.org/1528841367)

--- a/lib/features/categories/api.category.model.dart
+++ b/lib/features/categories/api.category.model.dart
@@ -8,9 +8,9 @@ class ApiCategory with _$ApiCategory {
   const factory ApiCategory(
       {@Default(0) id,
       @Default('') uuid,
-      @Default('') langCode,
+      @JsonKey(name: 'langcode', defaultValue: '') langCode,
       @Default('') name,
-      @Default('') iconName,
+      @JsonKey(name: 'iconname', defaultValue: '') iconName,
       @Default(false) isCustom}) = _ApiCategory;
 
   factory ApiCategory.fromJson(Map<String, dynamic> json) => _$ApiCategoryFromJson(json);

--- a/lib/features/categories/api.category.model.dart
+++ b/lib/features/categories/api.category.model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'api.category.model.freezed.dart';

--- a/lib/features/categories/api.category.model.freezed.dart
+++ b/lib/features/categories/api.category.model.freezed.dart
@@ -22,8 +22,10 @@ ApiCategory _$ApiCategoryFromJson(Map<String, dynamic> json) {
 mixin _$ApiCategory {
   dynamic get id => throw _privateConstructorUsedError;
   dynamic get uuid => throw _privateConstructorUsedError;
+  @JsonKey(name: 'langcode', defaultValue: '')
   dynamic get langCode => throw _privateConstructorUsedError;
   dynamic get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'iconname', defaultValue: '')
   dynamic get iconName => throw _privateConstructorUsedError;
   dynamic get isCustom => throw _privateConstructorUsedError;
 
@@ -41,9 +43,9 @@ abstract class $ApiCategoryCopyWith<$Res> {
   $Res call(
       {dynamic id,
       dynamic uuid,
-      dynamic langCode,
+      @JsonKey(name: 'langcode', defaultValue: '') dynamic langCode,
       dynamic name,
-      dynamic iconName,
+      @JsonKey(name: 'iconname', defaultValue: '') dynamic iconName,
       dynamic isCustom});
 }
 
@@ -103,9 +105,9 @@ abstract class _$$_ApiCategoryCopyWith<$Res>
   $Res call(
       {dynamic id,
       dynamic uuid,
-      dynamic langCode,
+      @JsonKey(name: 'langcode', defaultValue: '') dynamic langCode,
       dynamic name,
-      dynamic iconName,
+      @JsonKey(name: 'iconname', defaultValue: '') dynamic iconName,
       dynamic isCustom});
 }
 
@@ -145,9 +147,9 @@ class _$_ApiCategory implements _ApiCategory {
   const _$_ApiCategory(
       {this.id = 0,
       this.uuid = '',
-      this.langCode = '',
+      @JsonKey(name: 'langcode', defaultValue: '') this.langCode,
       this.name = '',
-      this.iconName = '',
+      @JsonKey(name: 'iconname', defaultValue: '') this.iconName,
       this.isCustom = false});
 
   factory _$_ApiCategory.fromJson(Map<String, dynamic> json) =>
@@ -160,13 +162,13 @@ class _$_ApiCategory implements _ApiCategory {
   @JsonKey()
   final dynamic uuid;
   @override
-  @JsonKey()
+  @JsonKey(name: 'langcode', defaultValue: '')
   final dynamic langCode;
   @override
   @JsonKey()
   final dynamic name;
   @override
-  @JsonKey()
+  @JsonKey(name: 'iconname', defaultValue: '')
   final dynamic iconName;
   @override
   @JsonKey()
@@ -216,9 +218,9 @@ abstract class _ApiCategory implements ApiCategory {
   const factory _ApiCategory(
       {final dynamic id,
       final dynamic uuid,
-      final dynamic langCode,
+      @JsonKey(name: 'langcode', defaultValue: '') final dynamic langCode,
       final dynamic name,
-      final dynamic iconName,
+      @JsonKey(name: 'iconname', defaultValue: '') final dynamic iconName,
       final dynamic isCustom}) = _$_ApiCategory;
 
   factory _ApiCategory.fromJson(Map<String, dynamic> json) =
@@ -229,10 +231,12 @@ abstract class _ApiCategory implements ApiCategory {
   @override
   dynamic get uuid => throw _privateConstructorUsedError;
   @override
+  @JsonKey(name: 'langcode', defaultValue: '')
   dynamic get langCode => throw _privateConstructorUsedError;
   @override
   dynamic get name => throw _privateConstructorUsedError;
   @override
+  @JsonKey(name: 'iconname', defaultValue: '')
   dynamic get iconName => throw _privateConstructorUsedError;
   @override
   dynamic get isCustom => throw _privateConstructorUsedError;

--- a/lib/features/categories/api.category.model.g.dart
+++ b/lib/features/categories/api.category.model.g.dart
@@ -10,9 +10,9 @@ _$_ApiCategory _$$_ApiCategoryFromJson(Map<String, dynamic> json) =>
     _$_ApiCategory(
       id: json['id'] ?? 0,
       uuid: json['uuid'] ?? '',
-      langCode: json['langCode'] ?? '',
+      langCode: json['langcode'] ?? '',
       name: json['name'] ?? '',
-      iconName: json['iconName'] ?? '',
+      iconName: json['iconname'] ?? '',
       isCustom: json['isCustom'] ?? false,
     );
 
@@ -20,8 +20,8 @@ Map<String, dynamic> _$$_ApiCategoryToJson(_$_ApiCategory instance) =>
     <String, dynamic>{
       'id': instance.id,
       'uuid': instance.uuid,
-      'langCode': instance.langCode,
+      'langcode': instance.langCode,
       'name': instance.name,
-      'iconName': instance.iconName,
+      'iconname': instance.iconName,
       'isCustom': instance.isCustom,
     };

--- a/lib/features/categories/category.icons.map.dart
+++ b/lib/features/categories/category.icons.map.dart
@@ -7,4 +7,5 @@ const Map<String, IconData> categoryIcons = {
   'planets': Icons.rocket,
   'countries': Icons.place_sharp,
   'geography': Icons.place_outlined,
+  'mix': Icons.category,
 };


### PR DESCRIPTION
### Elements addressed by this pull request

The refactoring introducing `Freezed` has caused some `JSON` serialization / deserialization issues

- Explicit naming added for `JSON` ⬅️ ➡️ `Dart`
- new `'mix'` icon to map new `BE` Api categories 

### Checklist

- [ ] Unit tests completed
- [x] Tested NON-UI changes on at least one device
- [ ] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android
BEFORE | AFTER
-------- | -------
![image](https://user-images.githubusercontent.com/3459255/178149156-db17ed19-9fc6-49f0-af07-7763636b007d.png) | ![image](https://user-images.githubusercontent.com/3459255/178149086-45a87e30-e22f-436b-a23c-d9428fc1a146.png)
