### PR TITLE
feat: persist selected category

### DIFF
--- a/lib/features/game/game.store.dart
+++ b/lib/features/game/game.store.dart
@@ -41,7 +41,11 @@ abstract class _GameStoreBase with Store {
 
   Future<void> _initialize() async {
     List<ApiCategory> categories = await textsService.getCategories();
-    await selectCategory(categories.first);
+
+    String lastSelectedCategoryUuid = sp.getString(SharedPreferenceKey.lastSelectedCategory.name);
+    ApiCategory initialCategory = categories.where((element) => element.uuid == lastSelectedCategoryUuid).first;
+
+    await selectCategory(initialCategory);
   }
 
   @action

--- a/lib/features/game/game.store.dart
+++ b/lib/features/game/game.store.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:guess_the_text/services/storage/shared.preferences.enum.dart';
+import 'package:guess_the_text/services/storage/shared.preferences.services.dart';
 import 'package:mobx/mobx.dart';
 
 import '/features/categories/api.category.model.dart';
@@ -20,6 +22,7 @@ class GameStore extends _GameStoreBase with _$GameStore {}
 // The store-class
 abstract class _GameStoreBase with Store {
   final LoggerService logger = serviceLocator.get();
+  final SharedPreferencesService sp = serviceLocator.get();
   final TextsService textsService = serviceLocator.get();
   final GamePlayedItemsStorageService gamePlayedItemsStorageService = serviceLocator.get();
 
@@ -46,6 +49,11 @@ abstract class _GameStoreBase with Store {
     if (currentCategory.uuid == selected.uuid) {
       return;
     }
+
+    sp.setString(SharedPreferenceKey.lastSelectedCategory.name, selected.uuid).onError((e, stackTrace) {
+      logger.error("Can't write preference ${SharedPreferenceKey.lastSelectedCategory}", e, stackTrace: stackTrace);
+      return false;
+    });
 
     currentCategory = selected;
     currentCategoryPlayedItems = await gamePlayedItemsStorageService.getPlayedItems(currentCategory.uuid);

--- a/lib/features/game/game.store.dart
+++ b/lib/features/game/game.store.dart
@@ -42,7 +42,7 @@ abstract class _GameStoreBase with Store {
   Future<void> _initialize() async {
     List<ApiCategory> categories = await textsService.getCategories();
 
-    String lastSelectedCategoryUuid = sp.getString(SharedPreferenceKey.lastSelectedCategory.name);
+    String lastSelectedCategoryUuid = sp.getString(SharedPreferenceKey.lastSelectedCategory.name, defaultValue: categories.first.uuid);
     ApiCategory initialCategory = categories.where((element) => element.uuid == lastSelectedCategoryUuid).first;
 
     await selectCategory(initialCategory);

--- a/lib/services/storage/shared.preferences.enum.dart
+++ b/lib/services/storage/shared.preferences.enum.dart
@@ -1,6 +1,7 @@
 enum SharedPreferenceKey {
   appLanguage,
   appIsThemeDark,
+  lastSelectedCategory,
 }
 
 List<String> getAllSharedPreferenceKeys() => SharedPreferenceKey.values.map((e) => e.name).toList();


### PR DESCRIPTION
## [Issue 40](https://github.com/amwebexpert/guess_the_text/issues/40)
This fixes: #40 

### Elements addressed by this pull request
- Added new sharedPreferencesKey -> lastSelectedCategory
- Save lastSelectedCategory in sharedPreferences
- Load lastSelectedCategory in sharedPreferences, default to first ApiCategory in the list

### Checklist
- [ ] Unit tests completed
- [x] Tested NON-UI changes on at least one device
- [ ] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos
#### Persisting last selected category
[Screencast from 12-07-22 13:16:17.webm](https://user-images.githubusercontent.com/13435783/178477893-6956163b-0d93-4e04-b40d-c79516b5cd8e.webm)

#### Defaulting to the first category when there is no shared preferences available
[Screencast from 12-07-22 13:18:12.webm](https://user-images.githubusercontent.com/13435783/178478521-6b9708a5-4bc1-43cc-900a-1ad2aec51562.webm)


