### PR TITLE
fix: full width reusable compact table

### DIFF
--- a/lib/features/about/app.version.table.widget.dart
+++ b/lib/features/about/app.version.table.widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:guess_the_text/theme/widgets/compact.datatable.widget.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '/features/about/api.about.model.dart';
@@ -51,19 +52,7 @@ class _AppVersionTableState extends State<AppVersionTable> {
     return Column(
       children: [
         const PrivacyPolicyWidget(),
-        DataTable(
-          horizontalMargin: 0,
-          columnSpacing: 16,
-          headingRowHeight: 20,
-          dataRowHeight: 24,
-          columns: const <DataColumn>[
-            DataColumn(
-              label: Text(''),
-            ),
-            DataColumn(
-              label: Text(''),
-            ),
-          ],
+        CompactDatatableWidget(
           rows: <DataRow>[
             DataRow(
               cells: <DataCell>[

--- a/lib/features/about/author.info.table.widget.dart
+++ b/lib/features/about/author.info.table.widget.dart
@@ -1,60 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:guess_the_text/features/about/contributor.model.dart';
+import 'package:guess_the_text/theme/widgets/compact.datatable.widget.dart';
 
 import '../../theme/widgets/text.link.widget.dart';
 
-
 class AuthorInfoTable extends StatelessWidget {
-
   AuthorInfoTable({Key? key}) : super(key: key);
 
   final List<Contributor> _contributors = <Contributor>[
     Contributor(
-        name: 'André Masson',
-        email: 'amwebexpert@gmail.com',
-        linkedIn: 'https://www.linkedin.com/in/amwebexpert'),
-    Contributor(
-        name: 'Jef van der Avoirt',
-        email: 'jef.v.d.a@live.be',
-        linkedIn: 'https://www.linkedin.com/in/jefvda'),
+        name: 'André Masson', email: 'amwebexpert@gmail.com', linkedIn: 'https://www.linkedin.com/in/amwebexpert'),
+    Contributor(name: 'Jef van der Avoirt', email: 'jef.v.d.a@live.be', linkedIn: 'https://www.linkedin.com/in/jefvda'),
   ];
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Column(
-      children: [
-        DataTable(
-          horizontalMargin: 0,
-          columnSpacing: 16,
-          headingRowHeight: 20,
-          dataRowHeight: 24,
-          columns: <DataColumn>[
-            DataColumn(
-              label: Text(localizations.appAuthorName),
-            ),
-            DataColumn(
-              label: Text(localizations.appAuthorProfile),
-            ),
-          ],
-          rows: _contributors
-              .map((contributor) => DataRow(cells: <DataCell>[
-                    DataCell(
-                      ThemedTextLink(
-                          displayText: contributor.name,
-                          hyperlink: 'mailto:${contributor.email}'),
-                    ),
-                    DataCell(
-                      ThemedTextLink(
-                          displayText: 'Linked-in',
-                          hyperlink: contributor.linkedIn),
-                    )
-                  ]))
-              .toList(),
+    return CompactDatatableWidget(
+      columns: <DataColumn>[
+        DataColumn(
+          label: Text(localizations.appAuthorName),
+        ),
+        DataColumn(
+          label: Text(localizations.appAuthorProfile),
         ),
       ],
+      rows: _contributors
+          .map((contributor) => DataRow(cells: <DataCell>[
+                DataCell(
+                  ThemedTextLink(displayText: contributor.name, hyperlink: 'mailto:${contributor.email}'),
+                ),
+                DataCell(
+                  ThemedTextLink(displayText: 'Linked-in', hyperlink: contributor.linkedIn),
+                )
+              ]))
+          .toList(),
     );
   }
 }

--- a/lib/features/about/card.widget.dart
+++ b/lib/features/about/card.widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:guess_the_text/features/about/author.info.table.widget.dart';
+import 'package:guess_the_text/theme/widgets/height.spacer.widget.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
 import '/features/about/card.app.description.dart';
@@ -18,46 +19,41 @@ class AboutCard extends StatelessWidget {
     final isColumnLayout = ResponsiveWrapper.of(context).isSmallerThan(TABLET);
 
     return AboutCardPanel(
-      child: Column(
-        children: [
-          ResponsiveRowColumn(
-            rowMainAxisAlignment: MainAxisAlignment.spaceAround,
-            layout: isColumnLayout ? ResponsiveRowColumnType.COLUMN : ResponsiveRowColumnType.ROW,
-            children: [
-              const ResponsiveRowColumnItem(
-                rowFlex: 1,
-                child: CardHeaderWidget(),
-              ),
-              ResponsiveRowColumnItem(
-                rowFlex: 1,
-                child: Column(
-                  children: [
-                    SizedBox(height: spacing(6)),
-                    const AppVersionTable(),
-                    SizedBox(height: spacing(3)),
-                    AuthorInfoTable()
-                  ],
+      child: Padding(
+        padding: EdgeInsets.all(spacing(1)),
+        child: Column(
+          children: [
+            ResponsiveRowColumn(
+              rowMainAxisAlignment: MainAxisAlignment.spaceAround,
+              layout: isColumnLayout ? ResponsiveRowColumnType.COLUMN : ResponsiveRowColumnType.ROW,
+              children: [
+                const ResponsiveRowColumnItem(
+                  rowFlex: 1,
+                  child: CardHeaderWidget(),
                 ),
-              ),
-            ],
-          ),
-          Padding(
-            padding: EdgeInsets.fromLTRB(spacing(1), spacing(3), spacing(1), spacing(1.25)),
-            child: const CardAppDescriptionWidget(),
-          ),
-          Padding(
-            padding: EdgeInsets.all(spacing(1)),
-            child: const PlatformInfoTable(),
-          ),
-          Padding(
-            padding: EdgeInsets.all(spacing(1)),
-            child: const PlatformScreenInfoTable(),
-          ),
-          Padding(
-            padding: EdgeInsets.all(spacing(1)),
-            child: const MadeWithLoveWidget(),
-          ),
-        ],
+                ResponsiveRowColumnItem(
+                  rowFlex: 1,
+                  child: Column(
+                    children: [
+                      const HeightSpacer(spacingUnitCount: 6),
+                      const AppVersionTable(),
+                      const HeightSpacer(),
+                      AuthorInfoTable()
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const HeightSpacer(),
+            const CardAppDescriptionWidget(),
+            const HeightSpacer(),
+            const PlatformInfoTable(),
+            const HeightSpacer(),
+            const PlatformScreenInfoTable(),
+            const HeightSpacer(),
+            const MadeWithLoveWidget(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,6 @@
 {
   "about": "About this app",
-  "aboutMadeWithLove": "Make with love with Flutter framework!",
+  "aboutMadeWithLove": "Make with love with Flutter framework! Press the Flutter logo to access app libraries licences",
   "acceptChallengeCancelled": "QR Code scan cancelled",
   "actionCancel": "Cancel",
   "actionClose": "Close",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,6 +1,6 @@
 {
   "about": "À propos de l'app",
-  "aboutMadeWithLove": "Fait avec amour via le framework Flutter !",
+  "aboutMadeWithLove": "Fait avec amour via le framework Flutter ! Appuyez sur le logo de Flutter pour voir les lisences des librairies utilisées par l'application",
   "acceptChallengeCancelled": "Lecture de code QR annulée",
   "actionCancel": "Annuler",
   "actionClose": "Fermer",

--- a/lib/theme/widgets/compact.datatable.widget.dart
+++ b/lib/theme/widgets/compact.datatable.widget.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:guess_the_text/theme/theme.utils.dart';
+
+class CompactDatatableWidget extends StatelessWidget {
+  final List<DataColumn>? columns;
+  final List<DataRow> rows;
+
+  const CompactDatatableWidget({Key? key, this.columns, this.rows = const []}) : super(key: key);
+
+  List<DataColumn> _buildDataColumns(int count) => List.filled(count, const DataColumn(label: Text('')));
+  int get _columnsCountFromDataRows => rows.isNotEmpty ? rows[0].cells.length : 2;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+      width: double.infinity,
+      child: DataTable(
+        horizontalMargin: 0,
+        columnSpacing: spacing(2),
+        headingRowHeight: 20,
+        dataRowHeight: 24,
+        columns: columns ?? _buildDataColumns(_columnsCountFromDataRows),
+        rows: rows,
+      ));
+}

--- a/lib/theme/widgets/compact.datatable.widget.dart
+++ b/lib/theme/widgets/compact.datatable.widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:guess_the_text/theme/theme.utils.dart';
 
+/// @see https://stackoverflow.com/a/68507055/704681
 class CompactDatatableWidget extends StatelessWidget {
   final List<DataColumn>? columns;
   final List<DataRow> rows;

--- a/lib/theme/widgets/compact.datatable.widget.dart
+++ b/lib/theme/widgets/compact.datatable.widget.dart
@@ -17,8 +17,8 @@ class CompactDatatableWidget extends StatelessWidget {
       child: DataTable(
         horizontalMargin: 0,
         columnSpacing: spacing(2),
-        headingRowHeight: 20,
-        dataRowHeight: 24,
+        headingRowHeight: 26,
+        dataRowHeight: 26,
         columns: columns ?? _buildDataColumns(_columnsCountFromDataRows),
         rows: rows,
       ));

--- a/lib/theme/widgets/height.spacer.widget.dart
+++ b/lib/theme/widgets/height.spacer.widget.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:guess_the_text/theme/theme.utils.dart';
+
+class HeightSpacer extends StatelessWidget {
+  final double spacingUnitCount;
+
+  const HeightSpacer({Key? key, this.spacingUnitCount = 3}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+        height: spacing(spacingUnitCount),
+      );
+}

--- a/lib/theme/widgets/made.with.love.widget.dart
+++ b/lib/theme/widgets/made.with.love.widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 class MadeWithLoveWidget extends StatelessWidget {
   const MadeWithLoveWidget({Key? key}) : super(key: key);
@@ -7,19 +8,28 @@ class MadeWithLoveWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
+    const assetName = 'assets/images/drawer-header.svg';
 
-    return Column(
-      children: [
-        const FlutterLogo(
-          size: 100,
-          style: FlutterLogoStyle.horizontal,
-        ),
-        Text(
-          localizations.aboutMadeWithLove,
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.bodyText1,
-        ),
-      ],
+    return GestureDetector(
+      onTap: () => showAboutDialog(
+        context: context,
+        applicationIcon: SvgPicture.asset(assetName, height: 48, color: Theme.of(context).colorScheme.primary),
+        applicationName: localizations.appTitle,
+        applicationLegalese: localizations.appSubTitle,
+      ),
+      child: Column(
+        children: [
+          const FlutterLogo(
+            size: 100,
+            style: FlutterLogoStyle.horizontal,
+          ),
+          Text(
+            localizations.aboutMadeWithLove,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyText1,
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## [Issue 75](https://github.com/amwebexpert/guess_the_text/issues/75)

### Elements addressed by this pull request

- new full width reusable `CompactDatatableWidget`
- added `HeightSpacer` utility widget
- added licences access through `Flutter` logo `onTap` handler

### Checklist

- [ ] Unit tests completed
- [ ] Tested NON-UI changes on at least one device
- [x] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos


Webapp | Android
-------- | ---------
![image](https://user-images.githubusercontent.com/3459255/179359642-eac58d97-ea9f-4993-a073-80e8fec3c80a.png) | ![image](https://user-images.githubusercontent.com/3459255/179359887-153c1bc3-6c02-4808-bee2-230c25e85fcf.png)

Licences demo

Flutter dialog | View licenses
---------------- | -----------------
![image](https://user-images.githubusercontent.com/3459255/179360707-81c877a5-ecf0-48f4-8d2c-73d9d1216744.png) | ![image](https://user-images.githubusercontent.com/3459255/179360723-7a39aaa9-9926-4969-b0cd-c8d69574b0a1.png)
