### PR TITLE
fix: prefetch images to prevent lagging

### DIFF
--- a/lib/features/game/text_to_guess/text.to.guess.model.dart
+++ b/lib/features/game/text_to_guess/text.to.guess.model.dart
@@ -1,3 +1,5 @@
+import 'package:guess_the_text/utils/extensions/string.extensions.dart';
+
 class TextToGuess {
   static const String stateName = 'hangman';
   static const int maxTrials = 10;
@@ -19,6 +21,10 @@ class TextToGuess {
 
     return clone;
   }
+
+  bool get isEmpty => original.isBlank;
+
+  bool get isNotEmpty => original.isNotBlank;
 
   TextToGuess tryChar({required String c}) {
     TextToGuess mutation = TextToGuess.from(this);
@@ -53,7 +59,7 @@ class TextToGuess {
   }
 
   bool isGameOver() {
-    return isGameOverWithFailure() || isGameOverWithSuccess();
+    return isNotEmpty && (isGameOverWithFailure() || isGameOverWithSuccess());
   }
 
   bool isGameOverWithFailure() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lottie/lottie.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
@@ -44,6 +45,12 @@ class _HangmanAppState extends State<HangmanApp> {
 
     List<ApiCategory> categories = await textsService.getCategories();
     await textsService.getTexts(categories.first.uuid);
+
+    // prefetch game images so they are displayed without lagging
+    Future.wait([
+      precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-happy.svg'), null),
+      precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-01.svg'), null),
+    ]);
 
     // If the widget was removed from the tree while the asynchronous call was in flight
     if (!mounted) {


### PR DESCRIPTION
### Elements addressed by this pull request

- prefetch game images so they are displayed without lagging
- fixed success 💡 green image showing at startup

### Checklist

- [ ] Unit tests completed
- [ ] Tested NON-UI changes on at least one device
- [x] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Android

https://user-images.githubusercontent.com/3459255/179362186-10807714-8d0c-49e1-9f72-8207e2d450e2.mp4

#### Webapp

https://user-images.githubusercontent.com/3459255/179362562-f3d1acfb-f1c3-41e8-976d-750736736052.mov


