### PR TITLE
feat: cache retrieved data on API success

### DIFF
--- a/docs/sections/completed-subjects.md
+++ b/docs/sections/completed-subjects.md
@@ -38,6 +38,7 @@ List of demonstrated elements inside the codebase, divided by categories
 
 - Local storage using [Shared Preferences](https://pub.dev/packages/shared_preferences) for user settings
 - Usage of NoSQL database [Sembast solution](https://pub.dev/packages/sembast) to persisted guessed texts
+- Classic [text files read/write](https://docs.flutter.dev/cookbook/persistence/reading-writing-files) (see `FileService`)
 
 ### Dependencies injection (a.k.a. inversion of control IoC, Service locator)
 

--- a/lib/features/game/api.texts.service.dart
+++ b/lib/features/game/api.texts.service.dart
@@ -58,6 +58,8 @@ class TextsService {
     return _categories;
   }
 
+  String getCategoryCacheFilename(String categoryUuid) => 'category-$categoryUuid-texts.json';
+
   Future<List<ApiText>> getTexts(String categoryUuid) async {
     if (categoryUuid.isBlank) {
       return [];
@@ -70,7 +72,7 @@ class TextsService {
     String entriesUrl = '$apiPathCategories/$categoryUuid/texts';
     Uri url = Uri.https(hostName, entriesUrl);
 
-    String jsonContent = await _callCachedApi(url: url, cacheFile: 'category-$categoryUuid-texts.json');
+    String jsonContent = await _callCachedApi(url: url, cacheFile: getCategoryCacheFilename(categoryUuid));
     List array = convert.jsonDecode(jsonContent);
 
     // memoize text items

--- a/lib/features/game/api.texts.service.dart
+++ b/lib/features/game/api.texts.service.dart
@@ -127,7 +127,7 @@ class TextsService {
     }
 
     try {
-      return await fileService.read(filename: cacheFile!, directoryType: DirectoryType.appSupport);
+      return fileService.read(filename: cacheFile!, directoryType: DirectoryType.appSupport);
     } catch (e) {
       logger.error('\texception while reading $cacheFile', e);
       return '';

--- a/lib/features/game/api.texts.service.dart
+++ b/lib/features/game/api.texts.service.dart
@@ -128,7 +128,10 @@ class TextsService {
     }
 
     try {
-      return fileService.read(filename: cacheFile!, directoryType: DirectoryType.appSupport);
+      String jsonContent = await fileService.read(filename: cacheFile!, directoryType: DirectoryType.appSupport);
+      logger.info('\treturning cached content from $cacheFile');
+
+      return jsonContent;
     } catch (e) {
       logger.error('\texception while reading $cacheFile', e);
       return '';

--- a/lib/features/game/api.texts.service.dart
+++ b/lib/features/game/api.texts.service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert' as convert;
 import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 import 'package:guess_the_text/features/about/api.about.model.dart';
 import 'package:guess_the_text/features/categories/api.category.model.dart';
@@ -87,7 +88,7 @@ class TextsService {
       response = _validateApiResponse(response);
       String jsonContent = response.body;
 
-      if (cacheFile.isNotBlank) {
+      if (!kIsWeb && cacheFile.isNotBlank) {
         unawaited(cacheData(data: jsonContent, cacheFile: cacheFile!));
       }
 
@@ -121,7 +122,7 @@ class TextsService {
 
   Future<String> loadFromCache(String? cacheFile) async {
     logger.info('loading API data from $cacheFile');
-    if (cacheFile.isBlank) {
+    if (kIsWeb || cacheFile.isBlank) {
       logger.info('\tno cached file');
       return '';
     }

--- a/lib/service.locator.dart
+++ b/lib/service.locator.dart
@@ -1,17 +1,17 @@
 import 'package:get_it/get_it.dart';
-
-import '/documents.repository.dart';
-import '/features/game/api.texts.service.dart';
-import '/features/game/game.played.items.storage.service.dart';
-import '/features/game/game.store.dart';
-import '/services/device/device.info.service.dart';
-import '/services/logger/logger.service.dart';
-import '/services/qr/qr.code.service.dart';
-import '/services/storage/shared.preferences.services.dart';
-import '/store/fixed.delay.spinner.store.dart';
-import '/utils/animation.utils.dart';
-import '/utils/randomizer.utils.dart';
-import 'features/settings/settings.store.dart';
+import 'package:guess_the_text/documents.repository.dart';
+import 'package:guess_the_text/features/game/api.texts.service.dart';
+import 'package:guess_the_text/features/game/game.played.items.storage.service.dart';
+import 'package:guess_the_text/features/game/game.store.dart';
+import 'package:guess_the_text/features/settings/settings.store.dart';
+import 'package:guess_the_text/services/device/device.info.service.dart';
+import 'package:guess_the_text/services/file/file.service.dart';
+import 'package:guess_the_text/services/logger/logger.service.dart';
+import 'package:guess_the_text/services/qr/qr.code.service.dart';
+import 'package:guess_the_text/services/storage/shared.preferences.services.dart';
+import 'package:guess_the_text/store/fixed.delay.spinner.store.dart';
+import 'package:guess_the_text/utils/animation.utils.dart';
+import 'package:guess_the_text/utils/randomizer.utils.dart';
 
 final serviceLocator = GetIt.instance;
 
@@ -31,6 +31,7 @@ Future<GetIt> initServiceLocator() async {
   serviceLocator
     ..registerSingleton<GamePlayedItemsStorageService>(gameStorageService)
     ..registerLazySingleton<DeviceInfoService>(() => DeviceInfoService())
+    ..registerLazySingleton<FileService>(() => FileService())
     ..registerLazySingleton<TextsService>(() => TextsService())
     ..registerLazySingleton<GameStore>(() => GameStore())
     ..registerLazySingleton<FixedDelaySpinnerStore>(() => FixedDelaySpinnerStore())

--- a/lib/services/file/directory.enum.dart
+++ b/lib/services/file/directory.enum.dart
@@ -1,0 +1,1 @@
+enum DirectoryType { appSupport, temporary, documents }

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -32,8 +32,7 @@ class FileService {
   }
 
   Future<File> write({required String data, required String filename, required DirectoryType directoryType}) async {
-    final Directory directory = await getDirectory(directoryType);
-    final String fullFilenanme = join(directory.path, filename);
+    final String fullFilenanme = await buildFullFilename(directoryType, filename);
     final File file = await File(fullFilenanme).create(recursive: true);
 
     logger.info('writing data to file $fullFilenanme');
@@ -41,8 +40,7 @@ class FileService {
   }
 
   Future<String> read({required String filename, required DirectoryType directoryType}) async {
-    final Directory directory = await getDirectory(directoryType);
-    final String fullFilenanme = join(directory.path, filename);
+    final String fullFilenanme = await buildFullFilename(directoryType, filename);
     final File file = File(fullFilenanme);
 
     if (!file.existsSync()) {
@@ -52,5 +50,10 @@ class FileService {
 
     logger.info('reading data from $fullFilenanme');
     return file.readAsString(encoding: utf8);
+  }
+
+  Future<String> buildFullFilename(DirectoryType directoryType, String filename) async {
+    final Directory directory = await getDirectory(directoryType);
+    return join(directory.path, filename);
   }
 }

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -38,4 +38,13 @@ class FileService {
     logger.info('writing data to file $fullFilenanme');
     return file.writeAsString(data, mode: FileMode.write, encoding: utf8, flush: false);
   }
+
+  Future<String> read({required String filename, required DirectoryType directoryType}) async {
+    Directory supportDir = await getDirectory(directoryType);
+    String fullFilenanme = '${supportDir.path}/$filename';
+    File file = File(fullFilenanme);
+
+    logger.info('reading data from $fullFilenanme');
+    return file.readAsString(encoding: utf8);
+  }
 }

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -31,8 +31,8 @@ class FileService {
   }
 
   Future<File> write({required String data, required String filename, required DirectoryType directoryType}) async {
-    Directory supportDir = await getDirectory(directoryType);
-    String fullFilenanme = '${supportDir.path}/$filename';
+    Directory directory = await getDirectory(directoryType);
+    String fullFilenanme = '${directory.path}/$filename';
     File file = File(fullFilenanme);
 
     logger.info('writing data to file $fullFilenanme');
@@ -40,8 +40,8 @@ class FileService {
   }
 
   Future<String> read({required String filename, required DirectoryType directoryType}) async {
-    Directory supportDir = await getDirectory(directoryType);
-    String fullFilenanme = '${supportDir.path}/$filename';
+    Directory directory = await getDirectory(directoryType);
+    String fullFilenanme = '${directory.path}/$filename';
     File file = File(fullFilenanme);
 
     logger.info('reading data from $fullFilenanme');

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -32,18 +32,23 @@ class FileService {
   }
 
   Future<File> write({required String data, required String filename, required DirectoryType directoryType}) async {
-    Directory directory = await getDirectory(directoryType);
-    String fullFilenanme = join(directory.path, filename);
-    File file = File(fullFilenanme);
+    final Directory directory = await getDirectory(directoryType);
+    final String fullFilenanme = join(directory.path, filename);
+    final File file = await File(fullFilenanme).create(recursive: true);
 
     logger.info('writing data to file $fullFilenanme');
     return file.writeAsString(data, mode: FileMode.write, encoding: utf8, flush: false);
   }
 
   Future<String> read({required String filename, required DirectoryType directoryType}) async {
-    Directory directory = await getDirectory(directoryType);
-    String fullFilenanme = join(directory.path, filename);
-    File file = File(fullFilenanme);
+    final Directory directory = await getDirectory(directoryType);
+    final String fullFilenanme = join(directory.path, filename);
+    final File file = File(fullFilenanme);
+
+    if (!file.existsSync()) {
+      logger.error('file does not exists', fullFilenanme);
+      return '';
+    }
 
     logger.info('reading data from $fullFilenanme');
     return file.readAsString(encoding: utf8);

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:guess_the_text/service.locator.dart';
 import 'package:guess_the_text/services/file/directory.enum.dart';
 import 'package:guess_the_text/services/logger/logger.service.dart';
+import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class FileService {
@@ -32,7 +33,7 @@ class FileService {
 
   Future<File> write({required String data, required String filename, required DirectoryType directoryType}) async {
     Directory directory = await getDirectory(directoryType);
-    String fullFilenanme = '${directory.path}/$filename';
+    String fullFilenanme = join(directory.path, filename);
     File file = File(fullFilenanme);
 
     logger.info('writing data to file $fullFilenanme');
@@ -41,7 +42,7 @@ class FileService {
 
   Future<String> read({required String filename, required DirectoryType directoryType}) async {
     Directory directory = await getDirectory(directoryType);
-    String fullFilenanme = '${directory.path}/$filename';
+    String fullFilenanme = join(directory.path, filename);
     File file = File(fullFilenanme);
 
     logger.info('reading data from $fullFilenanme');

--- a/lib/services/file/file.service.dart
+++ b/lib/services/file/file.service.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:guess_the_text/service.locator.dart';
+import 'package:guess_the_text/services/file/directory.enum.dart';
+import 'package:guess_the_text/services/logger/logger.service.dart';
+import 'package:path_provider/path_provider.dart';
+
+class FileService {
+  final LoggerService logger = serviceLocator.get();
+  static final FileService _instance = FileService._privateConstructor();
+
+  factory FileService() => _instance;
+  FileService._privateConstructor();
+
+  Future<Directory> getDirectory(DirectoryType directoryType) async {
+    switch (directoryType) {
+      case DirectoryType.appSupport:
+        return getApplicationSupportDirectory();
+
+      case DirectoryType.documents:
+        return getApplicationDocumentsDirectory();
+
+      case DirectoryType.temporary:
+        return getTemporaryDirectory();
+
+      default:
+        logger.error('unsupported type, returning temporary dir as default', directoryType);
+        return getTemporaryDirectory();
+    }
+  }
+
+  Future<File> write({required String data, required String filename, required DirectoryType directoryType}) async {
+    Directory supportDir = await getDirectory(directoryType);
+    String fullFilenanme = '${supportDir.path}/$filename';
+    File file = File(fullFilenanme);
+
+    logger.info('writing data to file $fullFilenanme');
+    return file.writeAsString(data, mode: FileMode.write, encoding: utf8, flush: false);
+  }
+}


### PR DESCRIPTION
## [Issue 18](https://github.com/amwebexpert/guess_the_text/issues/18)

### Elements addressed by this pull request

- cache json content of successful API calls
- try to load from cache on network error

### Checklist

- [ ] Unit tests completed
- [x] Tested NON-UI changes on at least one device
- [ ] Tested UI changes on at least 2 of the following platforms: Android, iOS, Webapp, Linux
- [x] Added corresponding screen capture or video
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### Load and cache succeeded API calls

![image](https://user-images.githubusercontent.com/3459255/179371792-5f40ceb0-2ccb-4a98-ba6e-e8eb123dd7e3.png)

#### Offline mode

![image](https://user-images.githubusercontent.com/3459255/179371802-f7e30dad-a99a-429b-85e6-2c06a2c9a0c9.png)
