### PR TITLE
feat: allow user to undo category "swipe to delete" action

### DIFF
--- a/lib/features/categories/local/categories.list.widget.dart
+++ b/lib/features/categories/local/categories.list.widget.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:guess_the_text/features/categories/category.icons.map.dart';
 import 'package:guess_the_text/features/categories/local/edit.category.widget.dart';
 import 'package:guess_the_text/service.locator.dart';
 import 'package:guess_the_text/services/text.service/api.category.model.dart';
 import 'package:guess_the_text/services/text.service/sql.db.service.dart';
+import 'package:guess_the_text/theme/widgets/snackbar/snackbar.model.dart';
+import 'package:guess_the_text/theme/widgets/snackbar/snackbar.utils.dart';
 import 'package:guess_the_text/utils/language.utils.dart';
 
 import '/theme/theme.utils.dart';
@@ -48,40 +51,57 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
     }
   }
 
-  Future<void> _deleteCategory(ApiCategory category) async {
+  Future<void> _deleteCategory(BuildContext context, ApiCategory category, int index) async {
     await sqlDbService.deleteCategory(category);
     setState(() => categories.remove(category));
+
+    if (!mounted) {
+      return;
+    }
+
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final action = SnackBarAction(
+        label: 'UNDO',
+        onPressed: () {
+          sqlDbService.createCategory(category).then((restoredCategory) {
+            setState(() => categories.insert(index, restoredCategory));
+          });
+        });
+    showAppSnackbar(
+        context: context,
+        message: localizations.categoryDeletedMessage(category.name),
+        type: SnackbarType.info,
+        milliseconds: 4 * 1000,
+        action: action);
   }
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-        floatingActionButton:
-            FloatingActionButton(child: const Icon(Icons.add), onPressed: () => _createCategory(context)),
-        body: FullScreenAssetBackground(
-          assetImagePath: CategoriesListWidget.backgroundImage,
-          child: Padding(
-            padding: EdgeInsets.all(spacing(2)),
-            child: ListView.builder(
-                itemCount: categories.length,
-                itemBuilder: (context, index) {
-                  final category = categories[index];
-                  final id = category.id.toString();
+  Widget build(BuildContext context) => Scaffold(
+      floatingActionButton:
+          FloatingActionButton(child: const Icon(Icons.add), onPressed: () => _createCategory(context)),
+      body: FullScreenAssetBackground(
+        assetImagePath: CategoriesListWidget.backgroundImage,
+        child: Padding(
+          padding: EdgeInsets.all(spacing(2)),
+          child: ListView.builder(
+              itemCount: categories.length,
+              itemBuilder: (context, index) {
+                final category = categories[index];
+                final id = category.id.toString();
 
-                  return Dismissible(
-                      key: Key(id),
-                      onDismissed: (direction) => _deleteCategory(category),
-                      child: Card(
-                        key: ValueKey(id),
-                        child: ListTile(
-                          leading: Icon(categoryIcons[category.iconName]),
-                          title: Text(category.name),
-                          subtitle: Text(getLanguageFullNameFromCode(context, category.langCode)),
-                          onTap: () => _updateCategory(context, category, index),
-                        ),
-                      ));
-                }),
-          ),
-        ));
-  }
+                return Dismissible(
+                    key: Key(id),
+                    onDismissed: (direction) => _deleteCategory(context, category, index),
+                    child: Card(
+                      key: ValueKey(id),
+                      child: ListTile(
+                        leading: Icon(categoryIcons[category.iconName]),
+                        title: Text(category.name),
+                        subtitle: Text(getLanguageFullNameFromCode(context, category.langCode)),
+                        onTap: () => _updateCategory(context, category, index),
+                      ),
+                    ));
+              }),
+        ),
+      ));
 }

--- a/lib/features/categories/local/categories.list.widget.dart
+++ b/lib/features/categories/local/categories.list.widget.dart
@@ -61,7 +61,7 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
 
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     final action = SnackBarAction(
-        label: 'UNDO',
+        label: 'UNDO', // TODO Translate me
         onPressed: () {
           sqlDbService.createCategory(category).then((restoredCategory) {
             setState(() => categories.insert(index, restoredCategory));

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -20,6 +20,16 @@
   "appVersion": "Version",
   "categories": "Categories",
   "category": "Category",
+  "categoryDeletedMessage": "The category «{name}» has been deleted.",
+  "@categoryDeletedMessage": {
+      "description": "Category removed status message",
+      "placeholders": {
+          "name": {
+              "type": "String",
+              "example": "Planets"
+          }
+      }
+  },
   "categoryEdit": "Edit category",
   "categoryIcon": "Category icon",
   "categoryNew": "New category",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -20,6 +20,16 @@
   "appVersion": "Version",
   "categories": "Catégories",
   "category": "Catégorie",
+  "categoryDeletedMessage": "La catégorie «{name}» a été supprimée.",
+  "@categoryDeletedMessage": {
+      "description": "Category removed status message",
+      "placeholders": {
+          "name": {
+              "type": "String",
+              "example": "Planets"
+          }
+      }
+  },
   "categoryEdit": "Modifier la catégorie",
   "categoryIcon": "Icône de la catégorie",
   "categoryNew": "Nouvelle catégorie",

--- a/lib/services/text.service/sql.db.service.dart
+++ b/lib/services/text.service/sql.db.service.dart
@@ -5,12 +5,35 @@ import 'package:guess_the_text/services/file/directory.enum.dart';
 import 'package:guess_the_text/services/file/file.service.dart';
 import 'package:guess_the_text/services/logger/logger.service.dart';
 import 'package:guess_the_text/services/text.service/api.category.model.dart';
+import 'package:guess_the_text/services/text.service/api.text.model.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
 enum TableNames { category, text }
 
 enum CategoryColumns { id, uuid, langcode, name, iconname }
+
+enum TextColumns { id, categoryid, uuid, original, normalized }
+
+final _createTableCategory = '''
+  CREATE TABLE ${TableNames.category.name} (
+    ${CategoryColumns.id.name} INTEGER PRIMARY KEY,
+    ${CategoryColumns.uuid.name} TEXT,
+    ${CategoryColumns.langcode.name} TEXT,
+    ${CategoryColumns.name.name} TEXT,
+    ${CategoryColumns.iconname.name} TEXT
+  )
+''';
+
+final _createTableText = '''
+  CREATE TABLE ${TableNames.text.name} (
+    ${TextColumns.id.name} INTEGER PRIMARY KEY,
+    ${TextColumns.categoryid.name} INTEGER,
+    ${TextColumns.uuid.name} TEXT,
+    ${TextColumns.original.name} TEXT,
+    ${TextColumns.normalized.name} TEXT
+  )
+''';
 
 class SqlDbService {
   final LoggerService logger = serviceLocator.get();
@@ -19,16 +42,6 @@ class SqlDbService {
   static final SqlDbService _instance = SqlDbService._privateConstructor();
   Database? _db;
   final version = 1;
-
-  final _createTableCategory = '''
-    CREATE TABLE ${TableNames.category.name} (
-      ${CategoryColumns.id.name} INTEGER PRIMARY KEY,
-      ${CategoryColumns.uuid.name} TEXT,
-      ${CategoryColumns.langcode.name} TEXT,
-      ${CategoryColumns.name.name} TEXT,
-      ${CategoryColumns.iconname.name} TEXT
-    )
-  ''';
 
   factory SqlDbService() => _instance;
   SqlDbService._privateConstructor();
@@ -58,6 +71,7 @@ class SqlDbService {
   Future<void> _onCreate(Database db, int version) async {
     logger.info('creating sqflite db version $version');
     await db.execute(_createTableCategory);
+    await db.execute(_createTableText);
   }
 
   Future<List<ApiCategory>> getCategories() async {
@@ -88,5 +102,26 @@ class SqlDbService {
     final where = '${CategoryColumns.id.name} = ?';
     int result = await _getDb().delete(TableNames.category.name, where: where, whereArgs: [category.id]);
     logger.info('removed category ${category.name}, result: $result');
+  }
+
+  Future<ApiText> createText(ApiText text) async {
+    Map<String, dynamic> toInsert = text.toJson()..remove(TextColumns.id.name); // the 'id' value will be auto-generated
+    int newId = await _getDb().insert(TableNames.text.name, toInsert);
+    logger.info('created text id $newId - ${text.original}');
+    return text.copyWith(id: newId);
+  }
+
+  Future<ApiText> updateText(ApiText text) async {
+    Map<String, dynamic> toUpdate = text.toJson();
+    final where = '${TextColumns.id.name} = ?';
+    int result = await _getDb().update(TableNames.text.name, toUpdate, where: where, whereArgs: [text.id]);
+    logger.info('updated text ${text.original}, result: $result');
+    return text;
+  }
+
+  Future<void> deleteText(ApiText text) async {
+    final where = '${TextColumns.id.name} = ?';
+    int result = await _getDb().delete(TableNames.text.name, where: where, whereArgs: [text.id]);
+    logger.info('removed text ${text.original}, result: $result');
   }
 }

--- a/lib/theme/widgets/snackbar/snackbar.utils.dart
+++ b/lib/theme/widgets/snackbar/snackbar.utils.dart
@@ -3,15 +3,17 @@ import '/theme/theme.utils.dart';
 import '/theme/widgets/snackbar/snackbar.model.dart';
 import '/theme/widgets/snackbar/snackbar.widget.dart';
 
-void showAppSnackbar({required BuildContext context, required String message, required SnackbarType type}) {
-  const duration = Duration(milliseconds: 2000);
-  final shape = RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(spacing(1)),
-  );
+void showAppSnackbar({
+  required BuildContext context,
+  required String message,
+  required SnackbarType type,
+  int milliseconds = 2000,
+  SnackBarAction? action,
+}) {
+  final duration = Duration(milliseconds: milliseconds);
+  final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+  final shape = RoundedRectangleBorder(borderRadius: BorderRadius.circular(spacing(1)));
 
-  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-    content: SnackbarWidget(message: message, type: type),
-    shape: shape,
-    duration: duration,
-  ));
+  messenger.showSnackBar(SnackBar(
+      content: SnackbarWidget(message: message, type: type), shape: shape, duration: duration, action: action));
 }

--- a/lib/theme/widgets/snackbar/snackbar.widget.dart
+++ b/lib/theme/widgets/snackbar/snackbar.widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '/theme/theme.utils.dart';
+import 'package:guess_the_text/theme/theme.utils.dart';
 import '/theme/widgets/snackbar/snackbar.model.dart';
 
 class SnackbarWidget extends StatelessWidget {
@@ -11,12 +11,11 @@ class SnackbarWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
         Icon(snackbarIcons[type], color: Theme.of(context).colorScheme.secondary),
-        Padding(
-          padding: EdgeInsets.only(left: spacing(1)),
-          child: Text(message),
-        ),
+        SizedBox(width: spacing(2)),
+        Expanded(child: Text(message)),
       ],
     );
   }


### PR DESCRIPTION
### Elements addressed by this pull request

- allow user to undo category "swipe to delete" action
- sqlite service: enable add texts items under a category

### Checklist

- [ ] Unit tests completed
- [ ] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### iOS

https://user-images.githubusercontent.com/3459255/184502128-ff0d76f7-22ef-46c3-8ea3-f6d25d9d2e6e.mp4

#### macOS

https://user-images.githubusercontent.com/3459255/184502506-2265cb04-ad6a-4f52-bd89-b43ad93861fa.mov




