### PR TITLE
fix: long text to guess wrap

### DIFF
--- a/lib/features/game/text_to_guess/text.to.guess.animating.widget.dart
+++ b/lib/features/game/text_to_guess/text.to.guess.animating.widget.dart
@@ -14,6 +14,7 @@ class TextToGuessAnimating extends StatelessWidget {
     return TextToGuessPanel(
       child: DefaultTextStyle(
         style: style,
+        textAlign: TextAlign.center,
         child: AnimatedTextKit(
           animatedTexts: [WavyAnimatedText(text)],
           isRepeatingAnimation: true,

--- a/lib/features/game/text_to_guess/text.to.guess.panel.widget.dart
+++ b/lib/features/game/text_to_guess/text.to.guess.panel.widget.dart
@@ -7,9 +7,8 @@ class TextToGuessPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 58,
-      child: child,
+    return Column(
+      children: [child],
     );
   }
 }

--- a/lib/features/game/text_to_guess/text.to.guess.widget.dart
+++ b/lib/features/game/text_to_guess/text.to.guess.widget.dart
@@ -29,6 +29,11 @@ class TextToGuessWidget extends StatelessWidget {
 
     return isAnimated
         ? TextToGuessAnimating(text: text, style: textStyle)
-        : TextToGuessPanel(child: Text(text, style: textStyle));
+        : TextToGuessPanel(
+            child: Text(
+            text,
+            style: textStyle,
+            textAlign: TextAlign.center,
+          ));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,10 +45,10 @@ class _HangmanAppState extends State<HangmanApp> {
     final TextsService textsService = serviceLocator.get<TextsService>();
 
     List<ApiCategory> categories = await textsService.getCategories();
-    await textsService.getTexts(categories.first.uuid);
 
-    // prefetch game images so they are displayed without lagging
     Future.wait([
+      textsService.getTexts(categories.first.uuid),
+      // prefetch game images so they are displayed without lagging
       precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-happy.svg'), null),
       precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-01.svg'), null),
     ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ class _HangmanAppState extends State<HangmanApp> {
 
     Future.wait([
       textsService.getTexts(categories.first.uuid),
+
       // prefetch game images so they are displayed without lagging
       precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-happy.svg'), null),
       precachePicture(ExactAssetPicture(SvgPicture.svgStringDecoderBuilder, 'assets/images/hangman-01.svg'), null),


### PR DESCRIPTION
### Elements addressed by this pull request

- bug fix: allow long text to wrap center aligned
- optimize startup async tasks execution

### Checklist

- [ ] Unit tests completed
- [ ] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

macOS portrait | macOS landccape | iOS iPhone 13
--------------- | --------------- | ---------------
![image](https://user-images.githubusercontent.com/3459255/184596011-63a02622-3e3e-4bd3-ba36-6a5d662e30a0.png) | ![image](https://user-images.githubusercontent.com/3459255/184596043-42eaf91c-841d-4e05-85fc-7bfd20fb6def.png) | ![image](https://user-images.githubusercontent.com/3459255/184596075-eb78473a-dd9c-4bfa-a60f-ef55d609037f.png)

