### PR TITLE
feat: handle onSutmit for enter key press

### DIFF
--- a/lib/features/categories/local/categories.list.widget.dart
+++ b/lib/features/categories/local/categories.list.widget.dart
@@ -29,7 +29,8 @@ class CategoriesListWidget extends StatefulWidget {
 }
 
 class _CategoriesListWidgetState extends State<CategoriesListWidget> {
-  final SqlDbService sqlDbService = serviceLocator.get();
+  final SqlDbService? sqlDbService = serviceLocator.isRegistered<SqlDbService>() ? serviceLocator.get() : null;
+  late bool isFeatureSupported = sqlDbService?.isPlateformSupported ?? false;
   late List<ApiCategory> categories;
 
   @override
@@ -39,8 +40,7 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
   }
 
   Future<void> _createCategory() async {
-    final ApiCategory? result =
-        await showDialog(context: context, builder: (_) => const EditCategory(category: ApiCategory(), isNew: true));
+    final ApiCategory? result = await showDialog(context: context, builder: (_) => const EditCategory(category: ApiCategory(), isNew: true));
 
     if (result != null) {
       setState(() => categories.add(result));
@@ -48,8 +48,7 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
   }
 
   Future<void> _updateCategory(ApiCategory category, int index) async {
-    final ApiCategory? result =
-        await showDialog(context: context, builder: (_) => EditCategory(category: category, isNew: false));
+    final ApiCategory? result = await showDialog(context: context, builder: (_) => EditCategory(category: category, isNew: false));
 
     if (result != null) {
       setState(() => categories[index] = result);
@@ -66,16 +65,13 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
   }
 
   Future<void> _doDeleteCategory(ApiCategory category) async {
-    await sqlDbService.deleteCategory(category);
+    await sqlDbService?.deleteCategory(category);
 
     if (!mounted) {
       return;
     }
 
-    showAppSnackbar(
-        context: context,
-        message: AppLocalizations.of(context)!.categoryDeletedMessage(category.name),
-        type: SnackbarType.info);
+    showAppSnackbar(context: context, message: AppLocalizations.of(context)!.categoryDeletedMessage(category.name), type: SnackbarType.info);
     setState(() => categories.remove(category));
   }
 
@@ -88,10 +84,9 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
 
   @override
   Widget build(BuildContext context) {
+    // TODO early return feature-not-supported whenever isFeatureSupported is false
     return Scaffold(
-        floatingActionButton: FloatingActionButton(
-            onPressed: sqlDbService.isPlateformSupported ? _createCategory : null,
-            child: const Icon(Icons.add)),
+        floatingActionButton: FloatingActionButton(onPressed: isFeatureSupported ? _createCategory : null, child: const Icon(Icons.add)),
         body: FullScreenAssetBackground(
           assetImagePath: CategoriesListWidget.backgroundImage,
           child: Padding(
@@ -110,10 +105,7 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
                         child: ListTile(
                           leading: Icon(categoryIcons[category.iconName]),
                           title: Text(category.name, style: Theme.of(context).textTheme.bodyText1),
-                          trailing: ElevatedButton(
-                              style: listTileTralingButtonStyle,
-                              child: const Icon(Icons.edit),
-                              onPressed: () => _updateCategory(category, index)),
+                          trailing: ElevatedButton(style: listTileTralingButtonStyle, child: const Icon(Icons.edit), onPressed: () => _updateCategory(category, index)),
                           subtitle: Text(getLanguageFullNameFromCode(context, category.langCode)),
                           onTap: () => _editCategoryElements(category),
                         ),

--- a/lib/features/categories/local/categories.list.widget.dart
+++ b/lib/features/categories/local/categories.list.widget.dart
@@ -89,7 +89,9 @@ class _CategoriesListWidgetState extends State<CategoriesListWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        floatingActionButton: FloatingActionButton(onPressed: _createCategory, child: const Icon(Icons.add)),
+        floatingActionButton: FloatingActionButton(
+            onPressed: sqlDbService.isPlateformSupported ? _createCategory : null,
+            child: const Icon(Icons.add)),
         body: FullScreenAssetBackground(
           assetImagePath: CategoriesListWidget.backgroundImage,
           child: Padding(

--- a/lib/features/categories/local/local.categories.widget.dart
+++ b/lib/features/categories/local/local.categories.widget.dart
@@ -15,14 +15,18 @@ class LocalCategoriesWidget extends StatefulWidget {
 }
 
 class _LocalCategoriesWidgetState extends State<LocalCategoriesWidget> {
-  final SqlDbService sqlDbService = serviceLocator.get();
-
   late Future<List<ApiCategory>> _categoriesFuture;
 
   @override
   void initState() {
     super.initState();
-    _categoriesFuture = sqlDbService.isPlateformSupported ? sqlDbService.getCategories() : Future.value([]);
+
+    if (serviceLocator.isRegistered<SqlDbService>()) {
+      final SqlDbService sqlDbService = serviceLocator.get();
+      _categoriesFuture = sqlDbService.isPlateformSupported ? sqlDbService.getCategories() : Future.value([]);
+    } else {
+      _categoriesFuture = Future.value([]);
+    }
   }
 
   @override

--- a/lib/features/categories/local/local.categories.widget.dart
+++ b/lib/features/categories/local/local.categories.widget.dart
@@ -22,7 +22,7 @@ class _LocalCategoriesWidgetState extends State<LocalCategoriesWidget> {
   @override
   void initState() {
     super.initState();
-    _categoriesFuture = sqlDbService.getCategories();
+    _categoriesFuture = sqlDbService.isPlateformSupported ? sqlDbService.getCategories() : Future.value([]);
   }
 
   @override

--- a/lib/features/categories/local/texts/edit.text.widget.dart
+++ b/lib/features/categories/local/texts/edit.text.widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:uuid/uuid.dart';
 
@@ -55,6 +56,12 @@ class EditTextState extends State<EditText> {
     }
   }
 
+  void onSubmit() {
+    if (_formKey.currentState!.validate()) {
+      _saveText(context).then((text) => Navigator.pop(context, text));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
@@ -64,17 +71,13 @@ class EditTextState extends State<EditText> {
       title: title,
       content: Form(
         key: _formKey,
-        child: TextFormFieldTextName(controller: _txtTextController),
+        child: TextFormFieldTextName(controller: _txtTextController, onEnterKeyPressed: onSubmit),
       ),
       actions: <Widget>[
         TextButton(onPressed: () => Navigator.pop(context), child: Text(localizations.actionCancel)),
         ElevatedButton(
+          onPressed: onSubmit,
           child: Text(localizations.actionOK),
-          onPressed: () {
-            if (_formKey.currentState!.validate()) {
-              _saveText(context).then((text) => Navigator.pop(context, text));
-            }
-          },
         ),
       ],
     );
@@ -83,15 +86,24 @@ class EditTextState extends State<EditText> {
 
 class TextFormFieldTextName extends StatelessWidget {
   final TextEditingController controller;
+  final VoidCallback onEnterKeyPressed;
 
-  const TextFormFieldTextName({Key? key, required this.controller}) : super(key: key);
+  const TextFormFieldTextName({Key? key, required this.controller, required this.onEnterKeyPressed}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final focusNode = FocusNode(onKey: (node, event) {
+      if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
+        onEnterKeyPressed();
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    });
 
     return TextFormField(
       autofocus: true,
+      focusNode: focusNode,
       enableSuggestions: false,
       maxLines: 3,
       autocorrect: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,27 +1,37 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lottie/lottie.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
-import '/features/settings/settings.store.dart';
-import '/route.generator.dart';
-import '/service.locator.dart';
-import '/theme/app.theme.dart';
-import '/theme/widgets/app.error.widget.dart';
-import '/utils/animation.utils.dart';
-import '/utils/randomizer.utils.dart';
-import 'services/text.service/api.category.model.dart';
-import 'services/text.service/api.texts.service.dart';
+import './features/settings/settings.store.dart';
+import './route.generator.dart';
+import './service.locator.dart';
+import './services/logger/logger.service.dart';
+import './services/text.service/api.category.model.dart';
+import './services/text.service/api.texts.service.dart';
+import './theme/app.theme.dart';
+import './theme/widgets/app.error.widget.dart';
+import './utils/animation.utils.dart';
+import './utils/randomizer.utils.dart';
 
 void main() {
   if (!kDebugMode) {
     ErrorWidget.builder = (FlutterErrorDetails details) => AppErrorWidget(details: details);
   }
-  // debugRepaintRainbowEnabled = true;
-  runApp(const HangmanApp());
+  debugRepaintRainbowEnabled = false;
+
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    runApp(const HangmanApp());
+  }, (error, stackTrace) {
+    LoggerService().error('unhandled error occured in root zone', error, stackTrace: stackTrace);
+  });
 }
 
 class HangmanApp extends StatefulWidget {

--- a/lib/service.locator.dart
+++ b/lib/service.locator.dart
@@ -34,10 +34,12 @@ Future<GetIt> initServiceLocator() async {
   await gameStorageService.init();
 
   final sqlDbService = await SqlDbService().init();
+  if (sqlDbService != null) {
+    serviceLocator.registerSingleton<SqlDbService>(sqlDbService);
+  }
 
   serviceLocator
     ..registerSingleton<GamePlayedItemsStorageService>(gameStorageService)
-    ..registerSingleton<SqlDbService>(sqlDbService)
     ..registerLazySingleton<DeviceInfoService>(() => DeviceInfoService())
     ..registerLazySingleton<TextsService>(() => TextsService())
     ..registerLazySingleton<GameStore>(() => GameStore())


### PR DESCRIPTION
### Elements addressed by this pull request

- handle `onSubmit` on `ENTER` key press for text entries
- added protection for `sqlite` unsupported platforms

### Checklist

- [ ] Unit tests completed
- [x] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

#### macOS - sqlite support and ENTER key interceptor

https://user-images.githubusercontent.com/3459255/184922903-6f51bb46-b977-47c5-9527-6cb59e26a773.mov

#### Android - sqlite support

https://user-images.githubusercontent.com/3459255/184925228-75fc4ad7-deb1-4e96-b7e7-fcbf63964a2d.mov

#### Web - NO sqlite support

https://user-images.githubusercontent.com/3459255/184924621-efc257ed-1813-4271-a926-79c46f9ece57.mov


