### PR TITLE
refactor: apply divide to conquer rule for big widgets

### DIFF
--- a/lib/features/about/about.screen.dart
+++ b/lib/features/about/about.screen.dart
@@ -7,6 +7,8 @@ import '/theme/widgets/app.bar.title.widget.dart';
 import '/theme/widgets/full.screen.bg.image.widget.dart';
 import 'card.widget.dart';
 
+const isPortraitOrientationLocked = false; // TODO Create a preferences for this feature
+
 class AboutWidget extends StatefulWidget {
   const AboutWidget({Key? key}) : super(key: key);
 
@@ -20,7 +22,9 @@ class _AboutWidgetState extends State<AboutWidget> {
   @override
   void initState() {
     super.initState();
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    if (isPortraitOrientationLocked) {
+      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    }
 
     Future.delayed(const Duration(milliseconds: 400), () {
       if (mounted) {

--- a/lib/features/about/card.widget.dart
+++ b/lib/features/about/card.widget.dart
@@ -15,46 +15,48 @@ class AboutCard extends StatelessWidget {
   const AboutCard({Key? key}) : super(key: key);
 
   @override
+  Widget build(BuildContext context) => AboutCardPanel(
+        child: Padding(
+          padding: EdgeInsets.all(spacing(1)),
+          child: Column(
+            children: const [
+              ResponsiveAboutHeaderPanel(),
+              HeightSpacer(),
+              CardAppDescriptionWidget(),
+              HeightSpacer(),
+              PlatformInfoTable(),
+              HeightSpacer(),
+              PlatformScreenInfoTable(),
+              HeightSpacer(),
+              MadeWithLoveWidget(),
+            ],
+          ),
+        ),
+      );
+}
+
+class ResponsiveAboutHeaderPanel extends StatelessWidget {
+  const ResponsiveAboutHeaderPanel({Key? key}) : super(key: key);
+
+  @override
   Widget build(BuildContext context) {
     final isColumnLayout = ResponsiveWrapper.of(context).isSmallerThan(TABLET);
 
-    return AboutCardPanel(
-      child: Padding(
-        padding: EdgeInsets.all(spacing(1)),
-        child: Column(
-          children: [
-            ResponsiveRowColumn(
-              rowMainAxisAlignment: MainAxisAlignment.spaceAround,
-              layout: isColumnLayout ? ResponsiveRowColumnType.COLUMN : ResponsiveRowColumnType.ROW,
-              children: [
-                const ResponsiveRowColumnItem(
-                  rowFlex: 1,
-                  child: CardHeaderWidget(),
-                ),
-                ResponsiveRowColumnItem(
-                  rowFlex: 1,
-                  child: Column(
-                    children: [
-                      const HeightSpacer(spacingUnitCount: 6),
-                      const AppVersionTable(),
-                      const HeightSpacer(),
-                      AuthorInfoTable()
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            const HeightSpacer(),
-            const CardAppDescriptionWidget(),
-            const HeightSpacer(),
-            const PlatformInfoTable(),
-            const HeightSpacer(),
-            const PlatformScreenInfoTable(),
-            const HeightSpacer(),
-            const MadeWithLoveWidget(),
-          ],
+    return ResponsiveRowColumn(
+      rowMainAxisAlignment: MainAxisAlignment.spaceAround,
+      layout: isColumnLayout ? ResponsiveRowColumnType.COLUMN : ResponsiveRowColumnType.ROW,
+      children: [
+        const ResponsiveRowColumnItem(
+          rowFlex: 1,
+          child: CardHeaderWidget(),
         ),
-      ),
+        ResponsiveRowColumnItem(
+          rowFlex: 1,
+          child: Column(
+            children: [const HeightSpacer(spacingUnitCount: 6), const AppVersionTable(), const HeightSpacer(), AuthorInfoTable()],
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### Elements addressed by this pull request

- do not force portrait mode anymore for the `About` screen (will be soon a user preference)
- apply _divide to conquer_ rule for `AboutCard` widget

### Checklist

- [ ] Unit tests completed
- [ ] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

Android landscape | Android portrait | iPhone portrait | iPhone landscape
---------------- | ---------------- | ---------------- | ----------------
![image](https://user-images.githubusercontent.com/3459255/185689533-e783d560-f4eb-4351-b54a-eb1b2cc69fc6.png) | ![image](https://user-images.githubusercontent.com/3459255/185689690-baa20de5-97f8-4264-98a3-970c159d039a.png) | ![image](https://user-images.githubusercontent.com/3459255/185690498-dfc055d1-6f0d-463c-8036-e94db938de5f.png) | ![image](https://user-images.githubusercontent.com/3459255/185690453-a1dd529e-664c-443d-b3a4-1bcdfdc1d3b2.png)

