### PR TITLE
feat: prevent local categories management for unsupported platforms

### DIFF
--- a/lib/features/categories/categories.screen.dart
+++ b/lib/features/categories/categories.screen.dart
@@ -6,6 +6,7 @@ import '../../service.locator.dart';
 import '../../services/logger/logger.service.dart';
 import '../../services/storage/shared.preferences.enum.dart';
 import '../../services/storage/shared.preferences.services.dart';
+import '../../services/text.service/sql.db.service.dart';
 import '../../theme/widgets/app.bar.title.widget.dart';
 import 'local/local.categories.widget.dart';
 import 'remote/remote.categories.widget.dart';
@@ -20,6 +21,7 @@ class CategoriesWidget extends StatefulWidget {
 class _CategoriesWidgetState extends State<CategoriesWidget> {
   final SharedPreferencesService preferences = serviceLocator.get();
   final LoggerService loggerService = serviceLocator.get();
+  final hasDeviceSqlSupport = serviceLocator.isRegistered<SqlDbService>();
 
   late int _currentIndex;
   late Widget _child;
@@ -61,9 +63,11 @@ class _CategoriesWidgetState extends State<CategoriesWidget> {
         appBar: AppBar(
           title: AppBarTitle(title: localizations.categories),
         ),
-        body: ResponsiveNavigationRailOrBar(items: [
-          NavigationChoices(text: localizations.categoryTypeCloud, icon: const Icon(Icons.cloud)),
-          NavigationChoices(text: localizations.categoryTypeDevice, icon: const Icon(Icons.save_alt)),
-        ], currentIndex: _currentIndex, onTap: _onTap, child: _child));
+        body: hasDeviceSqlSupport
+            ? ResponsiveNavigationRailOrBar(items: [
+                NavigationChoices(text: localizations.categoryTypeCloud, icon: const Icon(Icons.cloud)),
+                NavigationChoices(text: localizations.categoryTypeDevice, icon: const Icon(Icons.save_alt)),
+              ], currentIndex: _currentIndex, onTap: _onTap, child: _child)
+            : const RemoteCategoriesWidget());
   }
 }


### PR DESCRIPTION
### Elements addressed by this pull request

actually the app only supports `SQLite` for `Android`, `iOS` and `macOS`

- detect unsupported platform and prevent local categories management feature

### Checklist

- [ ] Unit tests completed
- [ ] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

Android | Webapp | MacBook
-------- | -------- | --------
![image](https://user-images.githubusercontent.com/3459255/187233802-fc53ff56-b743-4d57-9004-366ce57ff392.png) | ![image](https://user-images.githubusercontent.com/3459255/187233861-725b5080-8dd5-4a2e-898d-4fb05340cd3a.png) | ![image](https://user-images.githubusercontent.com/3459255/187233942-c69473de-27dc-4eff-a9a6-a45d7e7df458.png)


