### PR TITLE
feat: prevent qr code scan for unsupported platforms

### DIFF
--- a/lib/services/qr/qr.code.service.dart
+++ b/lib/services/qr/qr.code.service.dart
@@ -1,4 +1,7 @@
+import 'dart:io' show Platform;
+
 import 'package:barcode/barcode.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
 
 import '/utils/extensions/string.extensions.dart';
@@ -9,6 +12,8 @@ class QrCodeService {
   factory QrCodeService() => _instance;
 
   QrCodeService._privateConstructor();
+
+  bool isScanOperationSupported() => !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
   Future<String> scan({required String cancelLabel, String lineColor = '#ff6666', bool isShowFlashIcon = true}) async {
     final String data =

--- a/lib/theme/widgets/app.menu.widget.dart
+++ b/lib/theme/widgets/app.menu.widget.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import '/theme/widgets/app.menu.item.widget.dart';
 import '/theme/widgets/menu.logo.widget.dart';
+import '../../service.locator.dart';
+import '../../services/qr/qr.code.service.dart';
 
 class AppMenu extends StatelessWidget {
   final Function() onCreateChallengePress;
@@ -13,6 +16,7 @@ class AppMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
+    final QrCodeService qrCodeService = serviceLocator.get();
 
     return ListView(
       // Important: Remove any padding from the ListView.
@@ -35,14 +39,15 @@ class AppMenu extends StatelessWidget {
             onCreateChallengePress();
           },
         ),
-        MenuItemWidget(
-          titleLabel: localizations.appMenuReadChalenge,
-          iconName: 'adhocScan',
-          onTap: () {
-            Navigator.pop(context);
-            onAcceptChallengePress();
-          },
-        ),
+        if (qrCodeService.isScanOperationSupported())
+          MenuItemWidget(
+            titleLabel: localizations.appMenuReadChalenge,
+            iconName: 'adhocScan',
+            onTap: () {
+              Navigator.pop(context);
+              onAcceptChallengePress();
+            },
+          ),
         MenuItemWidget(
           titleLabel: localizations.preferences,
           iconName: 'preferences',


### PR DESCRIPTION
## [Issue 48](https://github.com/amwebexpert/guess_the_text/issues/48)

### Elements addressed by this pull request

- define the list of supported platforms
- detect unsupported platform and conditionally hide the app menu item feature

### Checklist

- [ ] Unit tests completed
- [ ] Tested `NON-UI` changes on at least one device
- [x] Tested `UI` changes on at least 2 of the following platforms: `Android`, `iOS`, `Webapp`, `Linux`, `macOS`, `Windows`
- [x] Added corresponding screen capture or video (recording)
- [x] This pull request conforms to [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

### Demos

MacBook | Webapp | Android
--------- | --------- | ---------
![image](https://user-images.githubusercontent.com/3459255/187239023-c3f783d9-dbb4-4996-8ccc-0bc46a880048.png) | ![image](https://user-images.githubusercontent.com/3459255/187239108-ffbec47a-6a45-4992-9521-031cffbca0e7.png) | ![image](https://user-images.githubusercontent.com/3459255/187239077-cc1a5348-dca9-44fe-9f4e-615ddc812f9d.png)
 

